### PR TITLE
Fix the link for PCS analytics page

### DIFF
--- a/products/info/pancakeswap-analytics.md
+++ b/products/info/pancakeswap-analytics.md
@@ -2,5 +2,5 @@
 
 ![](../../.gitbook/assets/screenshot-2020-11-02-at-3.53.09-pm.png)
 
-View PancakeSwap's native analytics site here: [https://pancakeswap.info/home](https://pancakeswap.info/home)
+View PancakeSwap's native analytics site here: [https://pancakeswap.info](https://pancakeswap.info)
 


### PR DESCRIPTION
The current link in PCS docs, which is https://pancakeswap.info/home, results in a 404 Error