### PR TITLE
updated: spelling 'remove' to 'removed'

### DIFF
--- a/products/pancakeswap-exchange/liquidity-guide.md
+++ b/products/pancakeswap-exchange/liquidity-guide.md
@@ -85,4 +85,4 @@ To remove liquidity.
 
 ![](<../../.gitbook/assets/Add\_Remove\_LP\_15 (1).png>)
 
-8\. After the transaction is confirmed. You will receive two of the tokens from your pair. And if you haven't remove all of your liquidity, your remaining liquidity value will be updated on "My Liquidity" page.\
+8\. After the transaction is confirmed. You will receive two of the tokens from your pair. And if you haven't removed all of your liquidity, your remaining liquidity value will be updated on "My Liquidity" page.\

--- a/products/pancakeswap-exchange/liquidity-guide.md
+++ b/products/pancakeswap-exchange/liquidity-guide.md
@@ -23,11 +23,11 @@ In this example, we will add liquidity using BNB and CAKE.\
 
 ![](../../.gitbook/assets/Add\_Remove\_LP\_02.png)
 
-3\. For the top Input, click 'Select a currency'. Then choose one of the token in the liquidity pair you want to add liquidity to. Here, we are gong to use BNB as an example.
+3\. For the top Input, click 'Select a currency'. Then choose one of the token in the liquidity pair you want to add liquidity to. Here, we are going to use BNB as an example.
 
 ![](../../.gitbook/assets/Add\_Remove\_LP\_03.png)
 
-4\. For the bottom input, click ‘Select a currency’. And choose the other token in the liquidity pair you want to add liquidity to. Here, we are gong to use CAKE as an example.
+4\. For the bottom input, click ‘Select a currency’. And choose the other token in the liquidity pair you want to add liquidity to. Here, we are going to use CAKE as an example.
 
 ![](../../.gitbook/assets/Add\_Remove\_LP\_04.png)
 


### PR DESCRIPTION
It appears that the verb **remove** should be in the past participle form.