### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/earn/ifo-initial-farm-offering/ifo-guide.md
+++ b/earn/ifo-initial-farm-offering/ifo-guide.md
@@ -116,7 +116,7 @@ If you don’t want to commit more CAKE to the IFO, you can skip ahead to the ne
 1. Let's commit some CAKE to the Public Sale. Click the **Commit** button under Public Sale. A window will appear.
 2.  In the new window, choose the amount of CAKE you want to commit in the field.
 
-    Remember, you can only commit up to to the number of iCAKE you have. And any CAKE you cannot spend on new tokens will be returned to you, so you don’t need to worry about losing any tokens.
+    Remember, you can only commit up to the number of iCAKE you have. And any CAKE you cannot spend on new tokens will be returned to you, so you don’t need to worry about losing any tokens.
 3. Click the **Confirm** button and confirm the action with your wallet. Once your CAKE are committed, the Public Sale section will show your committed amount.
 4. You can add more CAKE at any time during the IFO event as long as you haven’t reached the maximum limit. If you have, you will see "Max Committed" on the faded button. Keep in mind there is a fee for the Public Sale, listed next to “Additional fee”.
 

--- a/trade/trading-faq/swap-faq.md
+++ b/trade/trading-faq/swap-faq.md
@@ -46,7 +46,7 @@ With the transaction fee, whether it is inclusive (a portion of the swap amount 
 
 **Swapping with Transaction Fees**
 
-Before you swap any tokens, make sure you have visited their website to understand if they have a transaction fee mechanism (or _tax_ as many projects put it). If there is, make sure you set a slippage that is sufficient to accommodate the transaction fee -- e.g. if there is a transaction fee of 5%, your slippage will have to be set at at least 5% plus the normal trading slippage depending on your trading amount and the token's liquidity, say 5.5%-6%.
+Before you swap any tokens, make sure you have visited their website to understand if they have a transaction fee mechanism (or _tax_ as many projects put it). If there is, make sure you set a slippage that is sufficient to accommodate the transaction fee -- e.g. if there is a transaction fee of 5%, your slippage will have to be set at least 5% plus the normal trading slippage depending on your trading amount and the token's liquidity, say 5.5%-6%.
 
 In some extreme cases including some scams, some tokens even have a block on most or all transfers on chain, or only allowing certain addresses to sell, in such case it is impossible to swap the token successfully. Do learn about the token you are trying to swap and be aware of any fees and restrictions!
 


### PR DESCRIPTION
remove redundant words in comment