### PR TITLE
fix: update stale content across multiple documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### The people's choice
 
-PancakeSwap is a leading decentralized exchange. Available across ten chains: BNB Chain, Ethereum, Solana, Base, Arbitrum, Aptos, ZKsync, Linear, Monad, and opBNB, with the highest trading volumes in the market (sources: [1](https://www.coingecko.com/en/exchanges/decentralized) [2](https://coinmarketcap.com/rankings/exchanges/dex/)).
+PancakeSwap is a leading decentralized exchange. Available across ten chains: BNB Chain, Ethereum, Solana, Base, Arbitrum, Aptos, ZKsync, Linea, Monad, and opBNB, with the highest trading volumes in the market (sources: [1](https://www.coingecko.com/en/exchanges/decentralized) [2](https://coinmarketcap.com/rankings/exchanges/dex/)).
 
 ### Low fees
 

--- a/bridge/bridging/README.md
+++ b/bridge/bridging/README.md
@@ -29,11 +29,11 @@ Here are some reasons you may want to bridge:
 
 ## CAKE, a multichain token
 
-With our multichain expansion and deployment, CAKE is now a multichain token that is native to BNB Chain, but also available across Base, Arbitrum, Solana, Ethereum, ZKsync, Linea, opBNB, Aptos, and Polygon zkEVM.
+With our multichain expansion and deployment, CAKE is now a multichain token that is native to BNB Chain, but also available across Base, Arbitrum, Solana, Ethereum, ZKsync, Linea, opBNB, Aptos, and Monad.
 
 CAKE on any of the other chains is equal to CAKE on BNB Smart Chain. It can always be bridged between these chains at a 1:1 ratio and without any fee in CAKE.
 
-**Please note that there is only one CAKE.** There are no different versions of CAKE on different chains. The total supply of CAKE across all blockchains is capped at 450M, as outlined in this [vote proposal](https://pancakeswap.finance/voting/proposal/0x3e014aab40f6551da9f76da0e62e44e9ece55c4997f220057bf3e42dc8307c2f).
+**Please note that there is only one CAKE.** There are no different versions of CAKE on different chains. The total supply of CAKE across all blockchains is capped at 400M, as outlined in this [vote proposal](https://pancakeswap.finance/voting/proposal/0xc988547f7b6c435764c840623685b0c2d13ebcc91d1672d39c51b6d14207f9a5).
 
 ***
 
@@ -83,7 +83,8 @@ We currently integrate with:
 * opBNB
 * ZKsync
 * Linea
-* Polygon zkEVM
+* Monad
+* Solana
 * Aptos (V1 site)
 
 #### Tokens Available for Bridging
@@ -202,4 +203,6 @@ If a transaction is stuck for a long time, check the relevant explorer or reach 
    * `cakeOFT`: `0x3055913c90Fcc1A6CE9a358911721eEb942013A1` ([link](https://basescan.org/address/0x3055913c90Fcc1A6CE9a358911721eEb942013A1#code))
 9. **opBNB**
    * `cakeOFT`: `0x2779106e4F4A8A28d77A24c18283651a2AE22D1C` ([link](https://opbnbscan.com/address/0x2779106e4F4A8A28d77A24c18283651a2AE22D1C?tab=Contract\&p=1))
+10. **Monad**
+    * `cake`: `0xF59D81cd43f620E722E07f9Cb3f6E41B031017a3`
 

--- a/earn/cake-staking/README.md
+++ b/earn/cake-staking/README.md
@@ -1,8 +1,16 @@
 # 🥩 Cake Staking
 
-{% hint style="warning" %}
-As part of the [Tokenomics 3.0 upgrade](https://pancakeswap.finance/voting/proposal/0x79ef496c9737e48d9677a6e291ff2a549dee6729c9996398e453af8ecbf0ceb3), this main page and its related sub-pages will be updated.
+{% hint style="info" %}
+As part of the [Tokenomics 3.0 upgrade](https://pancakeswap.finance/voting/proposal/0x79ef496c9737e48d9677a6e291ff2a549dee6729c9996398e453af8ecbf0ceb3), the veCAKE system has been sunset. The information below reflects the current state of CAKE staking.
 {% endhint %}
 
+## Overview
 
+With Tokenomics 3.0, the previous veCAKE locking system has been deprecated. Key changes include:
 
+* **veCAKE sunset**: The veCAKE locking mechanism and its associated benefits (iCAKE, vCAKE, bCAKE, revenue sharing) have been removed.
+* **Simplified staking**: Users no longer need to lock CAKE for extended periods to access platform features.
+* **CAKE.PAD**: The new CAKE.PAD system (replacing IFO) allows users to commit CAKE to participate without requiring veCAKE or iCAKE.
+* **Increased burns**: The 5% revenue share previously distributed to veCAKE holders has been redirected to CAKE burns, increasing the burn rate from 10% to 15%.
+
+For more details on the current tokenomics, please refer to the [CAKE Tokenomics](../../protocol/cake-tokenomics.md) page.

--- a/earn/cakepad/README.md
+++ b/earn/cakepad/README.md
@@ -70,7 +70,7 @@ Each **CAKE.PAD event** has its **own smart contract**. You can find the contrac
 
 ### Want to Launch Your Own CAKE.PAD event?
 
-Bring your project directly to the **largest community on BNB Smart Chain**.
+Bring your project directly to the **largest community on BNB Smart Chain, Base, and Monad**.
 
 * Tap into PancakeSwap’s massive liquidity and user base
 * Get exposure right from launch

--- a/earn/yield-farming/README.md
+++ b/earn/yield-farming/README.md
@@ -37,7 +37,7 @@ On top of that, farmers receive **LP rewards** for providing liquidity. Here's a
 
 ![](https://lh4.googleusercontent.com/rJswz2qvCNTcODcClHxqlLpanSLsfbGtVw75MMPicBN1iKTKCuEYlPuoFAqskoy24DB9JBmATWb8dk3WmY1\_BFDZoS94sWTBZhZrcnG711rC8ltDXPR3gdl8D50eWq\_cfiBriKcl)
 
-In the WBNB/BUSD pair above, we see these values:
+In the WBNB/USDT pair above, we see these values:
 
 **Liquidity:** $387.42M\
 **Volume 24H:** $96.97M\
@@ -50,3 +50,7 @@ In the WBNB/BUSD pair above, we see these values:
     $164,849\*365 = **$60,169,885**
 * We can now use the yearly fees to calculate the **LP rewards APR:** That's **yearly fees** divided by **liquidity:**\
   ($60,169,885/$387,420,000)\*100 = **15.53% LP reward APR**
+
+{% hint style="info" %}
+Note: The values above are example figures for illustration purposes. Actual liquidity and volume numbers vary.
+{% endhint %}

--- a/trade/buy-crypto.md
+++ b/trade/buy-crypto.md
@@ -14,7 +14,7 @@ The on-ramp integration and quote system offers several key benefits for our use
 
 ### Structure and Fees
 
-On-ramp services will be available on **BNB, Ethereum, Arbitrum, Base, Linea, Polygon zkEVM and zkSync Era** chains. Major cryptocurrencies and stablecoins will be available and outlined in the table below:
+On-ramp services will be available on **BNB, Ethereum, Arbitrum, Base, Linea, and zkSync Era** chains. Major cryptocurrencies and stablecoins will be available and outlined in the table below:
 
 
 

--- a/trade/pancakeswap-exchange/market-maker-integration.md
+++ b/trade/pancakeswap-exchange/market-maker-integration.md
@@ -8,7 +8,7 @@ hidden: true
 
 ### Market Maker Integration on Ethereum
 
-PancakeSwap is integrated with market makers on Ethereum and Binance Smart Chain to help traders execute trades at a lower cost.
+PancakeSwap is integrated with market makers on Ethereum and BNB Smart Chain to help traders execute trades at a lower cost.
 
 In addition to the AMM, trades on PancakeSwap can now be routed to designated white-listed market makers if they offer trade execution that is better than the AMM’s current prices. This routing is done automatically by a [Smart Router](smart-router-v2/) so that trades are only routed to market makers when they are actively quoting better prices. Where the AMM is more competitive, traders will be routed to the AMMs for execution.
 
@@ -37,7 +37,7 @@ The following assets are currently supported and may increase/decrease depending
 **On Ethereum**
 
 * **Majors:** WETH, WBTC&#x20;
-* **Stablecoins:** USDT, USDC, DAI, BUSD
+* **Stablecoins:** USDT, USDC, DAI
 * **Other popular ERC-20 assets:** MATIC, DYDX, CRV, LINK, APE, CVX, STG, LDO, SNX, RNDR, FET
 
 **On Binance Smart Chain:**&#x20;

--- a/trade/pancakeswap-exchange/trade.md
+++ b/trade/pancakeswap-exchange/trade.md
@@ -2,11 +2,11 @@
 
 ![](../../.gitbook/assets/swap-trade-header.png)
 
-[**Token swaps**](https://pancakeswap.finance/swap) on PancakeSwap are a simple way to trade one token for another via automated liquidity pools on BNB Smart Chain, Ethereum and Aptos, and also with market makers when trading tokens on BNB Smart Chain and Ethereum.
+[**Token swaps**](https://pancakeswap.finance/swap) on PancakeSwap are a simple way to trade one token for another via automated liquidity pools across multiple chains including BNB Smart Chain, Ethereum, Arbitrum, Base, Linea, ZKsync, opBNB, Monad, Solana, and Aptos.
 
 ![](<../../.gitbook/assets/image (53).png>)
 
-When you make a token swap (trade) on the [BNB Smart Chain](https://pancakeswap.finance/swap?chain=bsc) or [Ethereum](https://pancakeswap.finance/swap?chain=eth) PancakeSwap Exchange, you will pay trading fees according to the type of liquidity pool your trade is being routed through. You may check the route details by clicking the magnifier icon on the “Route” section.
+When you make a token swap (trade) on PancakeSwap, you will pay trading fees according to the type of liquidity pool your trade is being routed through. You may check the route details by clicking the magnifier icon on the “Route” section.
 
 For Exchange V3 liquidity pools, there are currently four different fee tiers: 0.01%, 0.05%, 0.25%, and 1%.
 

--- a/trade/pancakeswap-x/README.md
+++ b/trade/pancakeswap-x/README.md
@@ -8,7 +8,7 @@ PancakeSwap X introduces a whole new way to trade your favourite assets on Panca
 * Gas-free swaps
 
 {% hint style="success" %}
-**PancakeSwap X is live on Arbitrum and Ethereum, supporting crypto tokens, and on BNB Chain, it supports real-world assets (RWAs) only.**
+**PancakeSwap X is live on Arbitrum, Ethereum, BNB Chain, and Base, supporting crypto tokens.**
 {% endhint %}
 
 > **Looking to integrate? Check out the technical guide for PancakeSwap X integration** [**here**](https://www.notion.so/PCSX-Tech-Integration-Guide-0eb33e93295644e9855ec2c34b58b0c4?source=copy_link)**.**

--- a/trade/pancakeswap-x/faqs.md
+++ b/trade/pancakeswap-x/faqs.md
@@ -2,7 +2,7 @@
 
 #### Which network is currently supported?
 
-PancakeSwap X is live on Arbitrum and Ethereum, supporting crypto tokens, and on BNB Chain, it supports real-world assets (RWAs) like tokenised stocks, bonds, and ETFs.
+PancakeSwap X is live on Arbitrum, Ethereum, BNB Chain, and Base, supporting crypto tokens.
 
 #### Is PancakeSwap X on by default?
 

--- a/trade/stableswap/classic-stableswap.md
+++ b/trade/stableswap/classic-stableswap.md
@@ -12,7 +12,11 @@ When you conduct a Swap (trade) on the StableSwap you will pay lower trading fee
 
 Fees for pairs are broken down in the table below:
 
-<table><thead><tr><th width="150">Stablepair</th><th width="132">Trading Fees</th><th width="118.33333333333331">LP Rewards</th><th width="124">CAKE Buyback</th><th>PancakeSwap Treasury</th></tr></thead><tbody><tr><td>USDT-BUSD</td><td>0.01%</td><td>0.005%</td><td>0.004%</td><td>0.001%</td></tr><tr><td>USDC-BUSD</td><td>0.01%</td><td>0.005%</td><td>0.004%</td><td>0.001%</td></tr><tr><td>USDC-USDT</td><td>0.01%</td><td>0.005%</td><td>0.004%</td><td>0.001%</td></tr><tr><td>HAY-BUSD</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr><tr><td>HAY-USDT</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr><tr><td>axlUSDC-USDT</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr><tr><td>BNBx-WBNB</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr><tr><td>stkBNB-WBNB</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr></tbody></table>
+<table><thead><tr><th width="150">Stablepair</th><th width="132">Trading Fees</th><th width="118.33333333333331">LP Rewards</th><th width="124">CAKE Buyback</th><th>PancakeSwap Treasury</th></tr></thead><tbody><tr><td>USDC-USDT</td><td>0.01%</td><td>0.005%</td><td>0.004%</td><td>0.001%</td></tr><tr><td>HAY-USDT</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr><tr><td>axlUSDC-USDT</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr><tr><td>BNBx-WBNB</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr><tr><td>stkBNB-WBNB</td><td>0.04%</td><td>0.02%</td><td>0.016%</td><td>0.004%</td></tr></tbody></table>
+
+{% hint style="warning" %}
+BUSD pairs (USDT-BUSD, USDC-BUSD, HAY-BUSD) have been deprecated following the sunset of BUSD by Paxos in February 2024.
+{% endhint %}
 
 The Kitchen will gradually roll out StableSwap pairs and revise the fees to test and improve the product further.
 

--- a/welcome-to-pancakeswap/roadmap.md
+++ b/welcome-to-pancakeswap/roadmap.md
@@ -4,7 +4,7 @@ description: '"Don''t call it a roadmap"'
 
 # 🗺️ Roadmap
 
-_Updated on August 15, 2024_
+_Updated on April 13, 2026_
 
 ### Finally, it's a roadmap not a to-do list.
 
@@ -12,20 +12,18 @@ Crypto moves fast, and we move fast too.
 
 Pivoting is a way of life.
 
-That means that we don’t publicly commit to specific timelines, so we can organize our development priorities based on market changes and developer resources.
+That means that we don't publicly commit to specific timelines, so we can organize our development priorities based on market changes and developer resources.
 
-Due to considerations of security and confidentiality, some items are not included in the ‘Cooking In’ section.
+Due to considerations of security and confidentiality, some items are not included in the 'Cooking In' section.
 
 <figure><img src="../.gitbook/assets/telegram-cloud-photo-size-5-6100658967458988041-y.jpg" alt=""><figcaption></figcaption></figure>
 
-### Cooking in Q3
+### Cooking Now
 
-* v4
-* DEX: New Trading Venue
-* Crosschain veCAKE Expansion
-* Web3 Quest Platform
-* UI/UX Revamp
-* Multichain Simple Staking
+* Multichain Expansion (new chains)
+* Infinity (v4) Expansion to more chains
+* DEX Enhancements & Smart Routing Improvements
+* CAKE.PAD Multichain Expansion
 
 ### Done
 
@@ -42,33 +40,34 @@ Due to considerations of security and confidentiality, some items are not includ
 * Multichain Swap & Liquidity
 * Deployment to Aptos Chain
 * Aptos PancakeSwap Bridge
-* v3- Swap & Liquidity Upgrade on BNB chain and Ethereum
+* v3 - Swap & Liquidity Upgrade on BNB chain and Ethereum
 * Market Maker Integration on Ethereum and BNB Chain
-* Expansion to Polygon zkEVM - Swap and Liquidity
+* Expansion to Polygon zkEVM - Swap and Liquidity (now sunset)
 * Expansion to Base - Swap and Liquidity
 * Expansion to Linea - Swap and Liquidity
 * Expansion to Arbitrum One - Swap and Liquidity
 * Expansion to zkSync Era - Swap and Liquidity
 * Expansion to opBNB - Swap
-* Perpetuals v2  to Arbitrum and BNB Chain
+* Expansion to Monad - Swap and Liquidity
+* Expansion to Solana - Swap
+* Perpetuals v2 to Arbitrum and BNB Chain
 * Perps v2 Expansion to Base, and opBNB
-* DEX Enhancement: v4 whitepaper
+* PancakeSwap Infinity (v4) - Deployed on BSC and Base
+* PancakeSwap X - Cross-chain intent-based trading
 * Multichain Perpetual
-
-
-
-
+* Crosschain Swaps via bridge aggregation
+* UI/UX Revamp
 
 #### Earn
 
 * CAKE Staking
   * Fixed-term Staking
   * CAKE Side Pool - Flexible CAKE staking on the side of locked staking
-* Fixed-Term Staking Benefits&#x20;
-  * iCAKE, IFO benefits
-  * vCAKE, weighted voting power
-  * bCAKE, farm yield booster
-  * Events with well-known projects
+* Tokenomics 3.0
+  * veCAKE sunset
+  * CAKE.PAD (simplified IFO replacement)
+  * Increased burn rate (10% to 15%)
+  * CAKE supply cap reduced to 400M
 * Farms
 * Crosschain Farming
 * Syrup Pools
@@ -81,10 +80,9 @@ Due to considerations of security and confidentiality, some items are not includ
 * Syrup Pools on Ethereum
 * Farm Auction
 * Liquid Staking Integration
-* Revenue Sharing Pool
 * Simple Staking Integration
-* vCAKE Update - Gause Design
 * v3 Position Manager
+* Infinity Farms on BSC and Base
 
 #### Win
 
@@ -93,34 +91,24 @@ Due to considerations of security and confidentiality, some items are not includ
   Duo currency with BNB and CAKE\
   with Chainlink Price Chart and Chainlink Keepers
 * Team Battle (Trading Comps as a Service)
-* Pottery\
-  Lottery by staking\
-  New Pottery cohort every month
 * Multichain Prediction
 
 #### NFT
 
-* NFT Market Phase 1 & 2(buy & sell whitelisted NFT collections)
+* NFT Market Phase 1 & 2 (buy & sell whitelisted NFT collections)
 * Customizable User Profile
 * NFT drops
 * Pancake Squad generative NFT collection
-* Mobox Gaming NFT Integration
 
 #### Site Upgrades / CAKE / Other Products
 
 * Mobile-first navigation & site overhaul
 * Analytics: Info site
 * IFO CAKE Pool & IFO 3.0
-* IFO
-  * Private Sales with NFT Utility
-  * cIFO, Private Sales with Pancake Profile points utility
-  * Token vesting
-  * iCAKE integration
 * PCS Mini-Program in Binance App
 * The first Aptos IFO
 * Ambassador Program
 * PancakeSwap Blog
-* vCAKE Product utilities
 * Fiat on Ramp Integration with MoonPay and Mercuryo
 * Affiliate Program
 * Website Revamp
@@ -128,6 +116,6 @@ Due to considerations of security and confidentiality, some items are not includ
 * Notification Services Integrations
 * Affiliates Initiative
 * Hashdit Risk Scanner
-
-
-
+* PostHog Analytics Integration
+* MEV Guard on BNB Chain
+* Social Login / Smart Wallet Integration


### PR DESCRIPTION
## Summary

Audited the entire documentation against the current pancake-frontend codebase and fixed stale content across 12 files:

### Critical Fixes
- **README.md**: Fixed typo "Linear" → "Linea" in chain list
- **Bridge page**: Updated CAKE supply cap from 450M → 400M (per Jan 2026 vote), replaced Polygon zkEVM (sunset) with Monad and Solana in supported chains, added Monad CAKE address
- **PCSX pages**: Updated supported chains — PCSX is now live on Arbitrum, Ethereum, BSC, and Base (was incorrectly listed as BSC=RWA only)
- **Swap/Trade page**: Expanded from 3 chains to all 10 supported chains
- **Roadmap**: Was 20 months stale (Aug 2024). Updated with shipped features: Infinity v4, Tokenomics 3.0, Monad/Solana expansion, PCSX, veCAKE sunset, etc.

### BUSD Deprecation Cleanup
- **StableSwap**: Removed deprecated BUSD pairs (USDT-BUSD, USDC-BUSD, HAY-BUSD) from fee table, added deprecation notice
- **Yield Farming**: Replaced BUSD pair in LP reward example with USDT
- **Market Maker**: Removed BUSD from supported stablecoin list, fixed "Binance Smart Chain" → "BNB Smart Chain"
- **Buy Crypto**: Removed sunset Polygon zkEVM from on-ramp chains

### Other Updates
- **CAKE Staking**: Replaced empty placeholder with actual Tokenomics 3.0 content (veCAKE sunset info)
- **CAKE.PAD**: Added Base and Monad chain support mention

## Test plan
- [ ] Verify all edited pages render correctly in GitBook
- [ ] Cross-check updated chain lists against live pancakeswap.finance UI
- [ ] Confirm CAKE supply cap of 400M matches on-chain data
- [ ] Verify PCSX is accessible on BSC and Base chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)