### PR TITLE
docs: additional sync with codebase (2026-04-14 v2)

### DIFF
--- a/play/prediction/README.md
+++ b/play/prediction/README.md
@@ -15,7 +15,7 @@ You can play PancakeSwap Prediction on:
 
 ### Summary: How It Works
 
-1. **Choose an asset to bet on**: Currently available on **BNB Chain** for BNBUSD, BTCUSD, and ETHUSD.
+1. **Choose an asset to bet on**: Currently available on **BNB Chain** for BNBUSD, BTCUSD, and ETHUSD. Also deployed on **zkSync** and **Arbitrum** (ETHUSD, currently paused).
 2. **Pick UP or DOWN**: Predict if the asset price will be higher or lower when the “LIVE” phase ends (each round = 5 minutes).
 3. Place your bet amount: Any BNB amount
 4. **Lock in your position**: Once placed, your bet cannot be changed.
@@ -25,7 +25,7 @@ You can play PancakeSwap Prediction on:
 
 ### Mechanics & Fees
 
-* **Supported Chain: BNB Chain**
+* **Supported Chains: BNB Chain, zkSync (paused), Arbitrum (paused)**
 * **Round frequency**: Every **5 minutes** (rolling rounds).
 * **Participation fee**: **3%** of each round’s total prize pool, a portion of which goes to **CAKE buybacks**.
 * **Winnings**: Claim anytime after results are finalized.

--- a/trade/pancakeswap-exchange/trade.md
+++ b/trade/pancakeswap-exchange/trade.md
@@ -2,7 +2,7 @@
 
 ![](../../.gitbook/assets/swap-trade-header.png)
 
-[**Token swaps**](https://pancakeswap.finance/swap) on PancakeSwap are a simple way to trade one token for another via automated liquidity pools on BNB Smart Chain, Ethereum and Aptos, and also with market makers when trading tokens on BNB Smart Chain and Ethereum.
+[**Token swaps**](https://pancakeswap.finance/swap) on PancakeSwap are a simple way to trade one token for another via automated liquidity pools on BNB Smart Chain, Ethereum, Arbitrum, Base, zkSync, Linea, opBNB, Monad, and Aptos, and also with market makers when trading tokens on BNB Smart Chain and Ethereum.
 
 ![](<../../.gitbook/assets/image (53).png>)
 

--- a/trade/pancakeswap-x/README.md
+++ b/trade/pancakeswap-x/README.md
@@ -8,8 +8,7 @@ PancakeSwap X introduces a whole new way to trade your favourite assets on Panca
 * Gas-free swaps
 
 {% hint style="success" %}
-**PancakeSwap X is live on Arbitrum and Ethereum, supporting crypto tokens, and on BNB Chain, it supports real-world assets (RWAs) only.**
+**PancakeSwap X is live on Arbitrum, Ethereum, and Base, supporting crypto tokens, and on BNB Chain, it supports real-world assets (RWAs) only.**
 {% endhint %}
 
 > **Looking to integrate? Check out the technical guide for PancakeSwap X integration** [**here**](https://www.notion.so/PCSX-Tech-Integration-Guide-0eb33e93295644e9855ec2c34b58b0c4?source=copy_link)**.**
-

--- a/trade/pancakeswap-x/faqs.md
+++ b/trade/pancakeswap-x/faqs.md
@@ -2,7 +2,7 @@
 
 #### Which network is currently supported?
 
-PancakeSwap X is live on Arbitrum and Ethereum, supporting crypto tokens, and on BNB Chain, it supports real-world assets (RWAs) like tokenised stocks, bonds, and ETFs.
+PancakeSwap X is live on Arbitrum, Ethereum, and Base, supporting crypto tokens, and on BNB Chain, it supports real-world assets (RWAs) like tokenised stocks, bonds, and ETFs.
 
 #### Is PancakeSwap X on by default?
 

--- a/trade/stableswap/infinity-stableswap.md
+++ b/trade/stableswap/infinity-stableswap.md
@@ -4,7 +4,7 @@
 
 Infinity StableSwap is a pool type within[ PancakeSwap Infinity](https://docs.pancakeswap.finance/trade/pancakeswap-infinity) optimized for swapping assets that should trade near the same price — such as stablecoins (e.g., USDC/USDT) or tightly-pegged assets (e.g., wrapped token pairs, liquid staking tokens, and liquid restaking tokens).
 
-It is powered by a StableSwap hook running on the Infinity architecture, inspired by Curve's StableSwap NG design. It is currently available on BNB Chain, with plans to expand to additional chains in the future.
+It is powered by a StableSwap hook running on the Infinity architecture, inspired by Curve's StableSwap NG design. It is currently available on BNB Chain and Base, with plans to expand to additional chains in the future.
 
 ***
 
@@ -194,4 +194,3 @@ Choose a Pool Parameter Preset — this automatically sets the recommended param
 6\. Click Preview Pool, review your settings, check the confirmation box, then click Create Pool.
 
 <figure><img src="../../.gitbook/assets/unknown (5).png" alt=""><figcaption></figcaption></figure>
-


### PR DESCRIPTION
## Documentation Sync — 2026-04-14 (v2)

Follow-up to #105. This PR covers pages that the initial scan missed, using the improved scan pipeline with page inventory, reverse scan, and expanded category checks.

### Drift detected

**Swap/Exchange (`trade/pancakeswap-exchange/trade.md`):**
- Chain list only said "BNB Smart Chain, Ethereum and Aptos" — updated to include Arbitrum, Base, zkSync, Linea, opBNB, and Monad

**PancakeSwap X (`trade/pancakeswap-x/README.md`, `faqs.md`):**
- Missing Base from supported chains — added "Arbitrum, Ethereum, and Base"

**Prediction (`play/prediction/README.md`):**
- Only listed BNB Chain — added zkSync and Arbitrum as deployed (currently paused) ETHUSD markets

**Infinity StableSwap (`trade/stableswap/infinity-stableswap.md`):**
- Said "BNB Chain" only — added Base (contracts deployed and operational)

### From reverse scan (undocumented code changes)
- Monad mainnet (ChainId 143) is fully integrated in the frontend (routing, farms, pools, network switcher) but barely documented
- Base added to IFO support chains and has a Cakepad mini app experience
- 0.01% fee tier added for limit orders
- Infinity Stable feature was launched then disabled/hidden in frontend
- Web notifications / Web3Inbox integration was removed from codebase

### Pages scanned (no drift)
- `trade/crosschain-swaps/README.md` — chain list matches source code
- `trade/perpetual-trading/` — V2 chain list appears consistent
- `earn/cakepad/` — up to date with Tokenomics 3.0

### Skipped (needs human judgment)
- `trade/pancakeswap-exchange/trade.md` — still mentions "market makers on BSC and Ethereum" only; may need broader update
- `trade/stableswap/classic-stableswap.md` — lists BUSD pairs (USDT-BUSD, USDC-BUSD, HAY-BUSD) that are likely defunct since BUSD was sunset
- `trade/limit-orders/README.md` — TWAP supported chains (BSC, Arbitrum, Base, Linea) are not documented; needs new section
- `trade/trading-faq/pancakeswap-infinity-faq.md` — pre-launch language ("Once launched in Q3"), stale stats ("1.8M users, $2.1B liquidity")
- `trade/trading-faq/swap-faq.md` — no mention of Infinity as a liquidity source, only talks about V3
- `earn/yield-farming/` — no mention of Monad, Base, opBNB, zkSync, Linea, Arbitrum as farming chains
- `earn/cake-staking/README.md` — blank placeholder page after Tokenomics 3.0 upgrade
- `tokenomics/untitled.md` — severely outdated (40 CAKE/block, 1.2M/day from 2020 era)
- `bridge/bridging/README.md` — missing Monad CAKE OFT address, missing Solana from bridge chain list
- `play/prediction/README.md` — bet currency section only mentions BNB; zkSync/Arbitrum use ETH
- `play/lottery/lottery-faq.md` — injection numbers inconsistent (8,000 CAKE/round in FAQ vs 35,000/week in frontend)
- `welcome-to-pancakeswap/contact-us/business-partnerships/README.md` — still lists Polygon zkEVM as active

---
Auto-generated by doc-sync agent. @ChefEric @chef-miso please review.