### PR TITLE
docs: fix typos and stale content (2026-04-15)

### DIFF
--- a/earn/cakepad/cakepad-guide.md
+++ b/earn/cakepad/cakepad-guide.md
@@ -27,7 +27,7 @@ Before you can join a CAKE.PAD event, the only thing you need to prepare is your
 CAKE tokens are used to buy the tokens being offered in the CAKE.PAD event
 
 * If your CAKE is staked in a Syrup Pool, unstake it before the CAKE.PAD event
-* Else, make sure to buy some CAKE tokens in advance and hold them in in your wallet
+* Else, make sure to buy some CAKE tokens in advance and hold them in your wallet
 
 ### Knowing when a CAKE.PAD Event will Start
 

--- a/earn/earn-faq/farming-faq.md
+++ b/earn/earn-faq/farming-faq.md
@@ -28,7 +28,7 @@ If the price moves back in range, the position will start receiving CAKE rewards
 
 ### Are there any ways to automatically adjust my position so it is always in range and earning fee rewards?
 
-Automatic position managing feature is coming soon to PancakeSwap v3 with one-click liquidity depositing (Zap!) and farming. Stay tuned for more detail.
+PancakeSwap supports automatic position management with one-click liquidity depositing (Zap!) and farming.
 
 
 

--- a/earn/yield-farming/how-to-use-farms/README.md
+++ b/earn/yield-farming/how-to-use-farms/README.md
@@ -32,7 +32,7 @@ Head to: [https://pancakeswap.finance/liquidity/pools](https://pancakeswap.finan
 2. All the liquidity positions you have.
 3. All the legacy farms. If you don't find your previously staked farms in "All Pools" try searching here.
 4. On default the page shows farms and tokens from all the supported chains. Use this drop down to filter pools by networks/chains.
-5. Use this dropdown to filter pools by by tokens.
+5. Use this dropdown to filter pools by tokens.
 6. Use this tab to filter pools by DEX type.
 7. Click the arrow button on APR, TVL, or VOLUME 24H to order the pools with the selected metrics.
 8. Sections for bCAKE - farm yield booster. [Learn more](../../../welcome-to-pancakeswap/vecake-sunset/bcake/)

--- a/trade/trading-faq/swap-faq.md
+++ b/trade/trading-faq/swap-faq.md
@@ -126,7 +126,7 @@ However, please bear in mind that only active liquidity positions will earn trad
 
 ### Are there any ways to automatically adjust my position so it is always in range and earning fee rewards?
 
-Automatic position managing feature is coming soon to PancakeSwap v3 with one-click liquidity depositing (Zap!). Stay tuned for more detail.
+PancakeSwap supports automatic position management with one-click liquidity depositing (Zap!).
 
 
 


### PR DESCRIPTION
## Documentation Sync — 2026-04-15 (auto-applied)

These are low-risk mechanical fixes applied automatically.

### Typos fixed
- `earn/cakepad/cakepad-guide.md:30` — "hold them in in your wallet" → "hold them in your wallet"
- `earn/yield-farming/how-to-use-farms/README.md:35` — "filter pools by by tokens" → "filter pools by tokens"

### Stale content updated
- `trade/trading-faq/swap-faq.md:129` — "Automatic position managing feature is coming soon...Zap!" → updated to present tense (Zap is live)
- `earn/earn-faq/farming-faq.md:31` — Same "coming soon" Zap language → updated to present tense

### Pages updated
- earn/cakepad/cakepad-guide.md
- earn/yield-farming/how-to-use-farms/README.md
- trade/trading-faq/swap-faq.md
- earn/earn-faq/farming-faq.md

---
Auto-applied by doc-sync agent (low-risk only). @ChefEric @chef-miso FYI.