### PR TITLE
docs: sync with codebase (2026-04-17)

### DIFF
--- a/bridge/bridging/README.md
+++ b/bridge/bridging/README.md
@@ -29,7 +29,7 @@ Here are some reasons you may want to bridge:
 
 ## CAKE, a multichain token
 
-With our multichain expansion and deployment, CAKE is now a multichain token that is native to BNB Chain, but also available across Base, Arbitrum, Solana, Ethereum, ZKsync, Linea, opBNB, Aptos, and Polygon zkEVM.
+With our multichain expansion and deployment, CAKE is now a multichain token that is native to BNB Chain, but also available across Base, Arbitrum, Solana, Ethereum, ZKsync, Linea, opBNB, Aptos, and Monad.
 
 CAKE on any of the other chains is equal to CAKE on BNB Smart Chain. It can always be bridged between these chains at a 1:1 ratio and without any fee in CAKE.
 
@@ -83,7 +83,7 @@ We currently integrate with:
 * opBNB
 * ZKsync
 * Linea
-* Polygon zkEVM
+* Monad
 * Aptos (V1 site)
 
 #### Tokens Available for Bridging


### PR DESCRIPTION
## Documentation Sync — 2026-04-17 (human-reviewed)

Approved by @ChefEric in #docs-sync channel. Scope: pancake-frontend-sourced drift.

### Changes applied

**`bridge/bridging/README.md`** — supported chain list drift:
- Removed **Polygon zkEVM** from the CAKE multichain prose and "Chains Currently Supported" list (sunset)
- Added **Monad** to both (CAKE is deployed on Monad and Monad is an active mainnet)

### Source verification

- `SunsetChainId.POLYGON_ZKEVM = 1101` → [pancake-frontend packages/chains/src/chainId.ts](https://github.com/pancakeswap/pancake-frontend/blob/develop/packages/chains/src/chainId.ts)
- `ChainId.MONAD_MAINNET = 143` → same file
- CAKE Monad address `0xF59D81cd43f620E722E07f9Cb3f6E41B031017a3` → [pancake-developer docs/pages/contracts/cake/index.md](https://github.com/pancakeswap/pancake-developer/blob/master/docs/pages/contracts/cake/index.md#L19)

### Skipped (not approved or uncertain)

- **Infinity StableSwap availability** (`trade/stableswap/infinity-stableswap.md`, `trade/pancakeswap-infinity/pool-types/infinity-stableswap.md`): pancake-frontend recently hid the UI (#12826), removed routing (#12794), removed pool selection paths (#12831), and marked the SDK as private. Docs still say "currently available on BNB Chain, with plans to expand." Skipped pending product clarification on whether this is a full rollback or temporary UI gate.

### Pages scanned (no drift)

- `welcome-to-pancakeswap/how-to-guides/get-started-monad/*` (Monad onboarding present)
- `welcome-to-pancakeswap/how-to-guides/get-started-sol/*` (Solana onboarding present)

---

Companion PR in pancake-developer covers contract/subgraph pages with the same sunset/dead-testnet cleanup.

Auto-generated by doc-sync agent. Reviewed by @ChefEric. @ChefEric @chef-miso please review.