### PR TITLE
docs: sync Infinity FAQ with current state (2026-04-20) — high-risk

### DIFF
--- a/trade/trading-faq/pancakeswap-infinity-faq.md
+++ b/trade/trading-faq/pancakeswap-infinity-faq.md
@@ -37,7 +37,7 @@ description: >-
 
 **Q4** Will there be any changes to the user interface or user experience in PancakeSwap Infinity?
 
-**Ans:** Once launched in Q3, users can swap on Infinity through PancakeSwap’s swapping page, just like the usual friendly experience.   For traders and liquidity providers, there will be more options to add liquidity as we support multiple pools, such as CLAMM and LBAMM, with detailed guidance provided upon launch.
+**Ans:** Users can swap on Infinity through PancakeSwap’s swapping page, just like the usual friendly experience. For traders and liquidity providers, there are more options to add liquidity as we support multiple pools, such as CLAMM and LBAMM, with detailed guidance available in our docs.
 
 **Q5** How can the community get involved in testing or providing feedback for PancakeSwap Infinity?
 
@@ -45,7 +45,7 @@ description: >-
 
 **Q6** Where can users find more information about PancakeSwap Infinity and stay updated on its development progress?
 
-**Ans:** Visit our official [website](https://pancakeswap.finance/v4?utm_source=v4announcementblog\&utm_medium=blog\&utm_campaign=v4announcementblog\&utm_id=v4announcementblog) , read our [whitepaper](https://github.com/pancakeswap/pancake-v4-core/blob/main/docs/whitepaper-en.pdf) , and follow us on social media for the latest updates and developments.  If you're a developer, join our developer Discord community.\
+**Ans:** Visit our official [website](https://pancakeswap.finance/v4?utm_source=v4announcementblog\&utm_medium=blog\&utm_campaign=v4announcementblog\&utm_id=v4announcementblog) , read our [whitepaper](https://github.com/pancakeswap/infinity-core/blob/main/docs/whitepaper-en.pdf) , and follow us on social media for the latest updates and developments.  If you're a developer, join our developer Discord community.\
 \
 **Q7** What is the licensing mechanism for PancakeSwap Infinity?
 


### PR DESCRIPTION
## Documentation Sync — 2026-04-20 (high-risk, needs review)

Scan target: `infinity-core`. Two stale references in the PancakeSwap Infinity FAQ.

### Changes applied

**`trade/trading-faq/pancakeswap-infinity-faq.md`**

1. **Q4 (line 40)** — "Once launched in Q3, users can swap on Infinity..." predates Infinity's mainnet launch on BSC (Mar 2025). Rewritten in present tense.
2. **Q6 (line 48)** — Whitepaper link pointed to `github.com/pancakeswap/pancake-v4-core` (GitHub redirects this but the repo was renamed to `infinity-core` in Feb 2025). Updated to canonical URL.

### Source verification

- Infinity BSC mainnet deployment commit: [pancakeswap/infinity-core#235 "feat: deploy on bsc mainnet"](https://github.com/pancakeswap/infinity-core/pull/235) (2025-03-06)
- Repo rename commit: [pancakeswap/infinity-core#230 "feat: refactor v4 to infinity"](https://github.com/pancakeswap/infinity-core/pull/230) (2025-02-05)

### Not changed (flagged but out of scope for this PR)

- Blog article URLs with `pancake-swap-v4` slug (lines 18, 30, 60, 64, 68) — those are `blog.pancakeswap.finance` URLs controlled by marketing, not the doc repo. Changing them could break links.
- Utm-tagged `pancakeswap.finance/v4` marketing URL in Q6 — same reason.

### Pages scanned (no drift)

- `trade/pancakeswap-infinity/README.md`
- `trade/pancakeswap-infinity/key-features.md`
- `trade/pancakeswap-infinity/faqs.md`
- `trade/pancakeswap-infinity/farms.md`
- `trade/pancakeswap-infinity/how-to-guides.md`
- `trade/pancakeswap-infinity/hooks/*`
- `trade/pancakeswap-infinity/pool-types/*`

---
Auto-generated by doc-sync agent. Merge to apply; close to reject; comment to request changes. @ChefEric @chef-miso please review.