### PR TITLE
docs: fix typos and casing (2026-04-20)

### DIFF
--- a/protocol/developers/contributing/codebase-overview.md
+++ b/protocol/developers/contributing/codebase-overview.md
@@ -11,7 +11,7 @@ All our repositories are stored on [Github](https://github.com/pancakeswap). Mos
 ## Github repositories
 
 * Frontend: The main frontend. It contains all the features that are not listed below.
-  * [sdk](https://github.com/pancakeswap/pancake-frontend/blob/develop/packages/swap-sdk) - An SDK for building applications on top of Pancakeswap
+  * [sdk](https://github.com/pancakeswap/pancake-frontend/blob/develop/packages/swap-sdk) - An SDK for building applications on top of PancakeSwap
   * [aptos-swap-sdk](https://github.com/pancakeswap/pancake-frontend/blob/develop/packages/aptos-swap-sdk) - Aptos version of Swap SDK
   * [swap-sdk-core](https://github.com/pancakeswap/pancake-frontend/blob/develop/packages/swap-sdk-core) - Swap SDK Shared code
   * [wagmi](https://github.com/pancakeswap/pancake-frontend/blob/develop/packages/wagmi) - Extension for [wagmi](https://github.com/wagmi-dev/wagmi), including bsc chain and binance wallet connector

--- a/trade/perpetual-trading/perpetual-trading-v2/README.md
+++ b/trade/perpetual-trading/perpetual-trading-v2/README.md
@@ -4,9 +4,9 @@ description: What's new in V2?
 
 # Perpetual Trading V2
 
-In Pancakeswap Perpetuals V2, we've streamlined our interface by **removing the order book and market depth displays**. Instead, our partners Aster have introduced the ALP pool, which now provides liquidity for all trading pairs, maximizing your capital usage. The ALP pool will actively participate in the market-making process for our V2 perpetual contracts. Please [visit this page](https://docs.asterdex.com/product/asterex-simple/price-oracles) to read more on the V2 low latency oracle model.
+In PancakeSwap Perpetuals V2, we've streamlined our interface by **removing the order book and market depth displays**. Instead, our partners Aster have introduced the ALP pool, which now provides liquidity for all trading pairs, maximizing your capital usage. The ALP pool will actively participate in the market-making process for our V2 perpetual contracts. Please [visit this page](https://docs.asterdex.com/product/asterex-simple/price-oracles) to read more on the V2 low latency oracle model.
 
-The new mechanism will bring added benefits to Pancakeswap Perpetual Users:
+The new mechanism will bring added benefits to PancakeSwap Perpetual Users:
 
 #### Enhanced Security
 
@@ -14,7 +14,7 @@ By tapping into Pyth, Binance Oracle and Chainlink price feeds, we dodge any une
 
 #### Self-Custody Freedom
 
-No more tedious deposits and withdrawals to trade with Pancakeswap Perpertuals V2. Users will trade fully on-chain, and no deposit and withdrawal requirements exist. Users can be assured that no protocol can manage, increase or reduce trading positions outside of a liquidation event.
+No more tedious deposits and withdrawals to trade with PancakeSwap Perpetuals V2. Users will trade fully on-chain, and no deposit and withdrawal requirements exist. Users can be assured that no protocol can manage, increase or reduce trading positions outside of a liquidation event.
 
 #### Higher Liquidity
 

--- a/trade/perpetual-trading/perpetual-trading-v2/dumb-mode/dumb-mode-guide.md
+++ b/trade/perpetual-trading/perpetual-trading-v2/dumb-mode/dumb-mode-guide.md
@@ -4,7 +4,7 @@
 
 To place an order in Dumb Mode on PancakeSwap, follow these steps:
 
-1. Select a Market: Go to [**Pancakeswap Perpertuals**](https://perp.pancakeswap.finance/en/futures/v2/BTCUSD?theme=light\&chain=bsc) on BSC. Choose from the available markets like BTCUSD, ETHUSD, etc.
+1. Select a Market: Go to [**PancakeSwap Perpetuals**](https://perp.pancakeswap.finance/en/futures/v2/BTCUSD?theme=light\&chain=bsc) on BSC. Choose from the available markets like BTCUSD, ETHUSD, etc.
 
 <figure><img src="../../../../.gitbook/assets/Module_Order.png" alt="" width="338"><figcaption></figcaption></figure>
 

--- a/trade/perpetual-trading/perpetual-trading-v2/perpetual-trading-faq/arbitrum/alp-syrup-pool-arbitrum/README.md
+++ b/trade/perpetual-trading/perpetual-trading-v2/perpetual-trading-faq/arbitrum/alp-syrup-pool-arbitrum/README.md
@@ -1,6 +1,6 @@
 # ALP Syrup Pool (Arbitrum)
 
-ALP is a token that powers liquidity on PancakeSwap Perpertuals V2. Users mint/buy ALP using collateral tokens such as USDC, USDT, DAI, ETH and BTC. These tokens supply liquidity to the PancakeSwap Perpetuals trade engine powered by ApolloX. ALP tokens **cannot be transferred between wallets** and can only be **minted/sold through ALP contract and staked in ALP pool**.
+ALP is a token that powers liquidity on PancakeSwap Perpetuals V2. Users mint/buy ALP using collateral tokens such as USDC, USDT, DAI, ETH and BTC. These tokens supply liquidity to the PancakeSwap Perpetuals trade engine powered by ApolloX. ALP tokens **cannot be transferred between wallets** and can only be **minted/sold through ALP contract and staked in ALP pool**.
 
 ### Step-By-Step Guide
 

--- a/welcome-to-pancakeswap/audits.md
+++ b/welcome-to-pancakeswap/audits.md
@@ -66,7 +66,7 @@
 
 * [OtterSec's PancakeSwap CAKE OFT (Aptos Token Bridging) security audit](https://1397868517-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2F-MHREX7DHcljbY5IkjgJ-1972196547%2Fuploads%2FMa0anQ4GXvFPyVLjFRxr%2FPancakeSwap-OFT-Audit-OtterSec.pdf?alt=media\&token=cbb22eb1-124c-4b07-9a73-175e019dde53) (Dec 2022)
 
-#### Aptos Pancakeswap IFO
+#### Aptos PancakeSwap IFO
 
 * [OtterSec's PancakeSwap Aptos IFO security audit](https://docs.pancakeswap.finance/code/smart-contracts-aptos/ifo#audits) (Dec 2022)
 


### PR DESCRIPTION
## Documentation Sync — 2026-04-20 (auto-applied, low-risk)

Low-risk content quality fixes. All mechanical fixes where the correct value is unambiguous.

### Casing fixes (Pancakeswap → PancakeSwap)
- `welcome-to-pancakeswap/audits.md` — "Aptos Pancakeswap IFO" heading
- `trade/perpetual-trading/perpetual-trading-v2/README.md` — three occurrences in body prose
- `trade/perpetual-trading/perpetual-trading-v2/dumb-mode/dumb-mode-guide.md` — link label
- `protocol/developers/contributing/codebase-overview.md` — SDK description

### Typo fixes (Perpertuals → Perpetuals)
- `trade/perpetual-trading/perpetual-trading-v2/README.md`
- `trade/perpetual-trading/perpetual-trading-v2/dumb-mode/dumb-mode-guide.md`
- `trade/perpetual-trading/perpetual-trading-v2/perpetual-trading-faq/arbitrum/alp-syrup-pool-arbitrum/README.md`

### Pages updated
- protocol/developers/contributing/codebase-overview.md
- trade/perpetual-trading/perpetual-trading-v2/README.md
- trade/perpetual-trading/perpetual-trading-v2/dumb-mode/dumb-mode-guide.md
- trade/perpetual-trading/perpetual-trading-v2/perpetual-trading-faq/arbitrum/alp-syrup-pool-arbitrum/README.md
- welcome-to-pancakeswap/audits.md

---
Auto-applied by doc-sync agent (low-risk only). @ChefEric @chef-miso FYI.