### PR TITLE
Fix: add GitBook redirects for old Chinese docs URLs

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,6 @@
+redirects:
+  click-here-for-help/troubleshooting-errors: welcome-to-pancakeswap/contact-us/faq/troubleshooting
+  click-here-for-help/README: welcome-to-pancakeswap/contact-us/faq/help
+  click-here-for-help/faq: welcome-to-pancakeswap/contact-us/faq/README
+  click-here-for-help/ru-he-xiu-fu-metamask-shang-ka-zhu-de-jiao-yi: welcome-to-pancakeswap/contact-us/faq/unsticking-a-transaction-stuck-as-pending-with-metamask
+  contact-us/customer-support: welcome-to-pancakeswap/contact-us/faq/help


### PR DESCRIPTION
## Summary

Adds `.gitbook.yaml` with redirects for legacy URL paths that return 404.

The old `click-here-for-help/` section was restructured into `welcome-to-pancakeswap/contact-us/faq/` but old URLs remained indexed/bookmarked. Users clicking them (e.g. `chinese/master/click-here-for-help/troubleshooting-errors`) get a "page not found" error.

## Redirects added

| Old path | New path |
|---|---|
| `click-here-for-help/troubleshooting-errors` | `welcome-to-pancakeswap/contact-us/faq/troubleshooting` |
| `click-here-for-help/README` | `welcome-to-pancakeswap/contact-us/faq/help` |
| `click-here-for-help/faq` | `welcome-to-pancakeswap/contact-us/faq/README` |
| `click-here-for-help/ru-he-xiu-fu-metamask-shang-ka-zhu-de-jiao-yi` | `welcome-to-pancakeswap/contact-us/faq/unsticking-a-transaction-stuck-as-pending-with-metamask` |
| `contact-us/customer-support` | `welcome-to-pancakeswap/contact-us/faq/help` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01W183UWiPqmav6K8irhtuT4)_