### PR TITLE
docs: sync with codebase (2026-07-06)

### DIFF
--- a/welcome-to-pancakeswap/contact-us/business-partnerships/initial-farm-offerings-ifos.md
+++ b/welcome-to-pancakeswap/contact-us/business-partnerships/initial-farm-offerings-ifos.md
@@ -22,7 +22,7 @@ For more information about our token launchpad offerings (“[Initial Farm Offer
    * An interactive session with our community to clarify any questions and establish ✨vibes✨
 5. IFO Launch
    * We will launch the IFO, and through our team of community admins, we will monitor, collate, and communicate any feedback raised by the community
-   * We will also publish some marketing materials on our [Twitter](https://app.gitbook.com/o/-MHRKTpKSfYQBsO7YgOo/s/fxRem6Hv7x6dAU7rlR7a/) and [Telegram](https://t.me/PancakeSwapAnn/6131)
+   * We will also publish some marketing materials on our [Twitter](https://x.com/PancakeSwap) and [Telegram](https://t.me/PancakeSwapAnn/6131)
 6. Post-Launch
    * We will continue to stay in touch, and work together wherever possible!&#x20;
 

--- a/welcome-to-pancakeswap/contact-us/telegram-and-discord-communities.md
+++ b/welcome-to-pancakeswap/contact-us/telegram-and-discord-communities.md
@@ -16,7 +16,7 @@ Join our official Telegram and Discord communities to connect with other users, 
 
 🔹 **Telegram Announcements (English)**: [https://t.me/PancakeSwapAnn](https://t.me/PancakeSwapAnn)
 
-🔹 **Discord**: [https://discord.gg/pancakeswap](https://t.me/PancakeSwap)
+🔹 **Discord**: [https://discord.gg/pancakeswap](https://discord.gg/pancakeswap)
 
 #### 🌍 **Local Communities**
 

--- a/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/masterchef-v2/README.md
+++ b/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/masterchef-v2/README.md
@@ -44,7 +44,7 @@ Note that the new `PoolInfo` struct **does not** contain the lp token address fi
 
 Use `lpToken.balanceOf(MasterChef.address)` to get the total staking amount for any given farm pool.
 
-However, In MasterChef v2, the users' share can be boosted (coming soon). Therefore, rewards are calculated using a new `totalBoostedShare` field in `PoolInfo` as each pool’s total shares. For example, if pool 0 has 2 users, user1 stake 100 LPs (without boost), user2 stake 100 (with `boostMultiplier` being 1.05), then the `totalBoostedShare` will become 205. Resulting in user2 gaining more rewards.
+However, In MasterChef v2, the users' share can be boosted. Therefore, rewards are calculated using a new `totalBoostedShare` field in `PoolInfo` as each pool’s total shares. For example, if pool 0 has 2 users, user1 stake 100 LPs (without boost), user2 stake 100 (with `boostMultiplier` being 1.05), then the `totalBoostedShare` will become 205. Resulting in user2 gaining more rewards.
 
 #### CakePerBlock
 


### PR DESCRIPTION
## Documentation Sync — 2026-07-06 (auto-applied)

Generated automatically by the doc-sync cloud routine. All changes below were applied without a human gate — please review before merging.

**Note on scope this run:** this run's GitHub access was scoped to `pancake-frontend`, `pancake-document`, and `pancake-developer` only. The other 7 source repos (infinity-core, infinity-periphery, pancake-v3-contracts, pancake-subgraph, pancake-contracts-move, infinity-universal-router, pancake-smart-contracts) could not be searched, so claims that depend on those repos (Infinity/StableSwap contract details, subgraph endpoints, Aptos module addresses, V3-contracts-specific data, legacy V2 contract source) were not verified this run.

### Low-risk fixes (typos, broken links, formatting)
- `welcome-to-pancakeswap/contact-us/telegram-and-discord-communities.md` — Discord link text/href mismatch: href pointed to `t.me/PancakeSwap` under a "Discord" label. Fixed href → `https://discord.gg/pancakeswap`.
- `welcome-to-pancakeswap/contact-us/business-partnerships/initial-farm-offerings-ifos.md` — "Twitter" link pointed to an internal `app.gitbook.com` editor URL (not publicly accessible). Fixed → `https://x.com/PancakeSwap` (PancakeSwap's official X handle, consistent with other links in the same doc).

### High-risk fixes (synced from codebase)
- `welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/masterchef-v2/README.md` — removed stale "(coming soon)" next to MasterChef v2 boosted-share description. Farm Booster / boosted staking (`boostMultiplier`, `bCakeFarmBooster*` contracts) has been live in `pancake-frontend` for a long time (multiple boost-related contracts/ABIs across `apps/web`, `packages/farms`, `packages/v3-sdk`).

### Source verification
- Boost feature: confirmed live via `boostMultiplier` / `bCakeFarmBooster*` / `UpdateBoostMultiplier` references across `pancake-frontend` (e.g. `apps/web/src/config/abi/masterchefV2.ts`, `packages/farms/constants/v3/abi/bCakeFarmBoosterVeCake.ts`).
- Discord/X links: manually verified against PancakeSwap's known official channels used elsewhere in the same doc repo.

### Needs reviewer decision (genuinely undecidable from sources / needs a product decision)
- **New Robinhood chain not yet documented.** `pancake-frontend` merged "feat: add Robinhood chain support (#13423)" on 2026-07-02 (`ChainId.ROBINHOOD = 4663`), enabling swap/v2/v3 routing on Robinhood chain. No page in this repo mentions Robinhood yet. We intentionally did **not** add it to any user-facing "supported chains" list here, since farms/Infinity/aggregator remain unsupported for this chain per the PR, and it's unclear whether this chain is publicly announced/launched from a marketing standpoint. (We did add the chain ID + contract addresses to the `pancake-developer` PR, since that's a pure technical reference unaffected by announcement timing.) Please confirm whether/where to add user-facing mentions.
- **Orphaned stale tokenomics page**: `tokenomics/untitled.md` (not linked from `SUMMARY.md`, so not part of site navigation, but still publicly reachable) contains CAKE 1.0-era emission data ("40 CAKE per block", "1,200,000 CAKE per day") that is years out of date and contradicts current tokenomics (`protocol/cake-tokenomics.md`, 400M supply cap, buy-back-and-burn model). This looks like true legacy content — same vintage as the already-archived `archive/old-tokenomics/` pages — but we didn't touch it since deleting/redirecting an orphaned page is a structural decision, not a data sync. Recommend either deleting it or moving it under `archive/`.

### Pages scanned (no drift found)
Full mechanical scan across `trade/`, `earn/`, `bridge/`, `play/`, `tokenomics/`, `products/`, `trading-tools/`, `welcome-to-pancakeswap/` for: `broken-reference` literals (none), doubled words (none), common misspellings (none), mismatched social links (2 found and fixed above, no others), stale "coming soon" language outside `archive/` (reviewed each instance — several are for third-party wallet features or perpetuals features we could not verify against an in-scope source repo, left unchanged), CAKE supply cap consistency (consistent at 400M across `protocol/cake-tokenomics.md` and `welcome-to-pancakeswap/contact-us/faq/README.md`).

---
Auto-generated by doc-sync routine. @ChefEric @chef-miso please review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MP96GKo26Gcz7u643oZJZa)_