### PR TITLE
docs: sync with codebase (2026-07-20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### The people's choice
 
-PancakeSwap is a leading decentralized exchange. Available across ten chains: BNB Chain, Ethereum, Solana, Base, Arbitrum, Aptos, ZKsync, Linea, Monad, and opBNB, with the highest trading volumes in the market (sources: [1](https://www.coingecko.com/en/exchanges/decentralized) [2](https://coinmarketcap.com/rankings/exchanges/dex/)).
+PancakeSwap is a leading decentralized exchange. Available across eleven chains: BNB Chain, Ethereum, Solana, Base, Arbitrum, Aptos, ZKsync, Linea, Monad, Robinhood, and opBNB, with the highest trading volumes in the market (sources: [1](https://www.coingecko.com/en/exchanges/decentralized) [2](https://coinmarketcap.com/rankings/exchanges/dex/)).
 
 ### Low fees
 

--- a/welcome-to-pancakeswap/contact-us/business-partnerships/trading-competitions.md
+++ b/welcome-to-pancakeswap/contact-us/business-partnerships/trading-competitions.md
@@ -4,7 +4,7 @@ Interested in boosting volumes and gaining mindshare for your project? Consider 
 
 We'll handle the set-up, tracking, and announcement - you provide the rewards, we run the show.
 
-This is available across BNB Chain, Solana, Base, Arbitrum, Ethereum, ZKsync, Linea, opBNB, and Polygon zkEVM.
+This is available across BNB Chain, Solana, Base, Arbitrum, Ethereum, ZKsync, Linea, and opBNB.
 
 _Some projects who took part previously saw a 3-7x increase in trading volume and actively traded addresses_
 

--- a/welcome-to-pancakeswap/contact-us/telegram-and-discord-communities.md
+++ b/welcome-to-pancakeswap/contact-us/telegram-and-discord-communities.md
@@ -16,7 +16,7 @@ Join our official Telegram and Discord communities to connect with other users, 
 
 🔹 **Telegram Announcements (English)**: [https://t.me/PancakeSwapAnn](https://t.me/PancakeSwapAnn)
 
-🔹 **Discord**: [https://discord.gg/pancakeswap](https://t.me/PancakeSwap)
+🔹 **Discord**: [https://discord.gg/pancakeswap](https://discord.gg/pancakeswap)
 
 #### 🌍 **Local Communities**
 

--- a/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/masterchef-v2/README.md
+++ b/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/masterchef-v2/README.md
@@ -44,7 +44,7 @@ Note that the new `PoolInfo` struct **does not** contain the lp token address fi
 
 Use `lpToken.balanceOf(MasterChef.address)` to get the total staking amount for any given farm pool.
 
-However, In MasterChef v2, the users' share can be boosted (coming soon). Therefore, rewards are calculated using a new `totalBoostedShare` field in `PoolInfo` as each pool’s total shares. For example, if pool 0 has 2 users, user1 stake 100 LPs (without boost), user2 stake 100 (with `boostMultiplier` being 1.05), then the `totalBoostedShare` will become 205. Resulting in user2 gaining more rewards.
+However, In MasterChef v2, the users' share can be boosted. Therefore, rewards are calculated using a new `totalBoostedShare` field in `PoolInfo` as each pool’s total shares. For example, if pool 0 has 2 users, user1 stake 100 LPs (without boost), user2 stake 100 (with `boostMultiplier` being 1.05), then the `totalBoostedShare` will become 205. Resulting in user2 gaining more rewards.
 
 #### CakePerBlock
 


### PR DESCRIPTION
## Documentation Sync — 2026-07-20 (auto-applied)

Generated automatically by the doc-sync cloud routine. All changes below were applied without a human gate — please review before merging.

Note on scope: this run's GitHub credentials were scoped to `pancake-frontend`, `pancake-document`, and `pancake-developer` only. The other source repos in the usual doc-sync source list (infinity-core, infinity-periphery, pancake-v3-contracts, pancake-subgraph, pancake-contracts-move, infinity-universal-router, pancake-smart-contracts) were not accessible this run, so claims that depend solely on those repos were not re-verified.

### Low-risk fixes (typos, broken links, formatting)
- `welcome-to-pancakeswap/contact-us/telegram-and-discord-communities.md` — the "Discord" entry's link text read `https://discord.gg/pancakeswap` but the href pointed to `https://t.me/PancakeSwap` (Telegram). Fixed href to match the display text.

### High-risk fixes (synced from codebase)
- `README.md` — homepage said "Available across ten chains" listing BNB Chain, Ethereum, Solana, Base, Arbitrum, Aptos, ZKsync, Linea, Monad, and opBNB. Robinhood chain (`ChainId.ROBINHOOD`, id 4663) is a live chain with `swap`/`liquidity`/`pools`/`farms` all enabled in `packages/chains/src/chains/robinhood.ts`, but wasn't in the list. Updated to "eleven chains" and added Robinhood.
- `welcome-to-pancakeswap/contact-us/business-partnerships/trading-competitions.md` — chain list for trading competitions included "Polygon zkEVM", which is `SunsetChainId.POLYGON_ZKEVM` in `packages/chains/src/chainId.ts` (explicitly deprecated). Removed it from the active list.
- `welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/masterchef-v2/README.md` — described MasterChef v2 boosted shares as "(coming soon)". Boost has shipped (see `apps/web/src/views/Farms/components/YieldBooster`, `v2BCakeWrapper` ABI/contracts). Removed the stale "(coming soon)" tag.

### Source verification
- Chain list / Robinhood: `pancake-frontend` `packages/chains/src/chainId.ts` (`ROBINHOOD = 4663`) and `packages/chains/src/chains/robinhood.ts` (features: swap/liquidity/pools/farms all `true`).
- Sunset chain: `pancake-frontend` `packages/chains/src/chainId.ts` → `SunsetChainId.POLYGON_ZKEVM`.
- Boost shipped: `pancake-frontend` `apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/useBCakeV3Info.ts`, `apps/web/src/config/abi/v2BCakeWrapper.ts`.

### Needs reviewer decision (genuinely undecidable from sources)
- `trade/trading-faq/limit-orders-faq.md` says "Stop Limit Orders feature is coming soon" for the spot Limit Orders product. The only "Stop Limit" order type found in `pancake-frontend` (`apps/web/src/views/Perpetuals/lib/orderTypeLabel.ts`) belongs to the separate Perpetuals/Aster product, not spot limit orders. Left as-is since this isn't solid evidence the spot product shipped it — needs product-team confirmation either way.

### Pages scanned (no drift)
- `README.md` (welcome-to-pancakeswap Product Overview) — perpetuals VIP fee tier "[Coming soon]" tag still accurate, no evidence of a shipped fee-discount feature in `pancake-frontend`.
- `play/prediction/README.md` — "BNB Chain, zkSync Era, and Arbitrum One" matches `prediction: true` in `packages/chains/src/chains/{bsc,zksync,arbitrum}.ts` exactly.
- Content-quality sweep across all ~299 markdown pages: no `broken-reference` literals, no common misspellings, no doubled-word typos found (a few regex hits were false positives — code samples like `Slot0 slot0`, date ranges like `11:00hrs ... 11`).

---
Auto-generated by doc-sync routine. @Chef Eric @Chef Miso please review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWzNGmi1VHDBhfJd3QbYrQ)_