### PR TITLE
docs: sync with codebase (2026-07-27)

### DIFF
--- a/products/coming-soon/new-cake-pool/README.md
+++ b/products/coming-soon/new-cake-pool/README.md
@@ -57,9 +57,9 @@ Stake your CAKE for a fixed amount of time to maximise yields and receive additi
 * CAKE rewards will unlock, along with your staked CAKE, when your lock duration expires
 * Once staked in fixed-term staking, you cannot withdraw until the end of your lock duration.
 * 🎁 Enjoy benefits such as:
-  * 🗳️ Boosted voting power: [vCAKE](../../../governance-and-tokenomics/voting/vecake.md)
-  * 🚜 Boosted farm yields: [bCAKE](../../yield-farming/bcake/)
-  * 🛍️ IFO public sale entry: [iCAKE](../../ifo-initial-farm-offering/icake.md)
+  * 🗳️ Boosted voting power: [vCAKE](../../../welcome-to-pancakeswap/vecake-sunset/archive-vecake/vecake.md)
+  * 🚜 Boosted farm yields: [bCAKE](../../../welcome-to-pancakeswap/vecake-sunset/bcake/)
+  * 🛍️ IFO public sale entry: [iCAKE](../../../welcome-to-pancakeswap/vecake-sunset/icake.md)
   * ✨ Priority access or special events
   * and so much more in our ongoing multichain expansion!
 


### PR DESCRIPTION
## Documentation Sync — 2026-07-27 (auto-applied)

Generated automatically by the doc-sync cloud routine. All changes below were applied without a human gate — please review before merging.

**Scope note:** this run's cross-referencing was restricted to `pancakeswap/pancake-frontend` only (not the full 8-repo source list in the routine config — the other 7 repos, e.g. contract repos, aren't in this session's GitHub access scope). Findings whose source of truth lives in an out-of-scope repo are listed below as "Needs reviewer decision" rather than guessed.

### Low-risk fixes (broken links)
- `products/coming-soon/new-cake-pool/README.md` — the vCAKE/bCAKE/iCAKE links pointed to paths from before the `welcome-to-pancakeswap/vecake-sunset/` directory restructure and 404'd. Fixed to point at the current locations (`vecake-sunset/archive-vecake/vecake.md`, `vecake-sunset/bcake/`, `vecake-sunset/icake.md`).

### High-risk fixes (synced from codebase)
None applied this run — the feature/chain claims checked (README.md chain count, perpetual trading fee tiers, degen mode chain list) all matched `pancake-frontend` or were undecidable (see below).

### Source verification
- README.md "eleven chains" claim cross-checked against `packages/chains/src/chainId.ts` (9 EVM chains + Solana/Aptos via `NonEVMChainId` = 11) — matches, no change needed.
- `trade/perpetual-trading/perpetuals-trading-new/README.md` "CAKE VIP Fee Tiers [Coming soon]" cross-checked against `apps/web/src/views/Perpetuals/**` — no CAKE-based fee-tier logic found in frontend; label is still accurate.

### Needs reviewer decision (genuinely undecidable from sources)
1. **`ecosystem-and-partnerships/contact-us/nft-market-applications.md`** (orphaned page, not linked from SUMMARY.md) — links to `../../contact-us/customer-support.md` and `../../contact-us/social-accounts-and-communities.md`, neither of which exists. No single unambiguous replacement target exists (closest candidates: `welcome-to-pancakeswap/contact-us/README.md` and `welcome-to-pancakeswap/contact-us/social-accounts.md` + `telegram-and-discord-communities.md`, but combining/splitting is a content decision).
2. **`trade/trading-faq/limit-orders-faq.md`** line 56 — "Stop Limit Orders feature is coming soon" sits in the deprecated Limit V2 (Gelato) section. That backend has no stop-limit code and likely never will ship it; the current live limit/TWAP product is a third-party Orbs widget not vendored in pancake-frontend, so whether Orbs offers/plans stop-limit orders can't be checked from source. Recommend a business-side check.
3. **`trade/perpetual-trading/perpetual-trading-v2/degen-mode/README.md`** — claims Degen Mode is BTCUSD-only on BNB/Arbitrum/opBNB/Base. This entire product (Perpetuals V2) is hosted externally (`perp.pancakeswap.finance`, proxied via `next.config.mjs`, not in the frontend monorepo), so pair list can't be verified from source. Also flagging an internal inconsistency: the sibling (non-hidden) page `perpetual-trading-v2/supported-chains-modes-and-markets.md` lists Degen Mode on the same 4 chains without the BTCUSD-only restriction, suggesting the two pages have drifted. This `hidden: true` page may also be a candidate for archiving given the new Aster-powered Perpetuals product appears to supersede V2.
4. **`welcome-to-pancakeswap/how-to-guides/get-started-aptos/wallet-guide.md`** — "Martian [wallet] mobile version is coming soon" — third-party wallet status, not checkable against pancake-frontend.
5. **Missing documentation** (found via reverse-scanning recent `pancake-frontend` commits, no prose written per the "only update data" edit rule — flagging for the docs team to write):
   - PancakeSwapX MultiReactor Router (new unified reactor router, PR #13600 et al.) — not mentioned anywhere in docs.
   - Large Stocks/RWA product expansion — dedicated Stocks trading terminal, new issuers (Reserve, bStocks, xStocks, Colb), new routing provider LiquidMesh, and a new Pre-IPO investing product. `trade/pancakeswap-x/rwas.md` still describes RWA trading as "powered by Ondo Finance" only and doesn't mention any of this.
   - "Scalp" order type for Perpetuals (PR #13309) not mentioned in any perps doc page.

### Pages scanned (no drift)
- All `README.md`/`faq.md`/`SUMMARY.md` top-level files — chain count consistent.
- Full `trade/`, `earn/`, `bridge/`, `play/`, `tokenomics/`, `products/` sections scanned for stale "coming soon"/temporal language, broken-reference literals, doubled words, common misspellings — no additional issues found beyond what's listed above.
- All internal `.md` cross-links repo-wide checked for link rot — only the 3 broken links noted above (1 fixed, 2 flagged for decision).
- Social media links (Discord/Telegram/Twitter/GitHub) — display text matches href consistently across the repo, no mismatches found.

---
Auto-generated by doc-sync routine. @ChefEric @chef-miso please review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtNAZsVuw12U4CjL4UzDX9)_