### PR TITLE
docs: sync with codebase (2026-08-17)

### DIFF
--- a/bridge/bridging/README.md
+++ b/bridge/bridging/README.md
@@ -83,6 +83,7 @@ We currently integrate with:
 * opBNB
 * ZKsync
 * Linea
+* Solana
 * Aptos (V1 site)
 
 #### Tokens Available for Bridging

--- a/earn/cake-staking/syrup-pool/README.md
+++ b/earn/cake-staking/syrup-pool/README.md
@@ -43,7 +43,7 @@ Find more information about our Syrup Pools [here](../../../welcome-to-pancakesw
 
 ### Syrup Pool Smart Contracts <a href="#docs-internal-guid-c4c16237-7fff-3c33-3a56-18ccd8853f86" id="docs-internal-guid-c4c16237-7fff-3c33-3a56-18ccd8853f86"></a>
 
-[CAKE Syrup Pool](/broken/pages/cFidohif6VdJE7LuwvlB)
+[CAKE Syrup Pool](https://developer.pancakeswap.finance/contracts/syrup-pools)
 
 ### &#x20;<a href="#docs-internal-guid-c4c16237-7fff-3c33-3a56-18ccd8853f86" id="docs-internal-guid-c4c16237-7fff-3c33-3a56-18ccd8853f86"></a>
 

--- a/earn/earn-faq/cake-staking-faq/vecake-faq.md
+++ b/earn/earn-faq/cake-staking-faq/vecake-faq.md
@@ -114,8 +114,8 @@ Voting vCAKE has now been upgraded to support veCAKE. Check out:
 
 All veCAKE holders (either native or migrated) will automatically enrolled in the new revenue sharing pool. Revenue shares are distributed according to the existing schedule. The old revenue sharing pool will be discontinued, users can claim their pending rewards by going to the benefit card. Check out:
 
-{% content-ref url="/broken/pages/wQegezs7c6A2HzQjPEjh" %}
-[Broken link](/broken/pages/wQegezs7c6A2HzQjPEjh)
+{% content-ref url="revenue-sharing-faq.md" %}
+[Revenue Sharing FAQ](revenue-sharing-faq.md)
 {% endcontent-ref %}
 
 #### Can multisig wallets be used for interacting with veCAKE?
@@ -162,4 +162,4 @@ To increase the emission to this gauge, check out [Gauge Voting](../../../welcom
 
 This is the incentive coming from protocol revenue sharing, coming from swap fees collected in DEX products.
 
-Check out [Revenue Sharing](/broken/pages/wQegezs7c6A2HzQjPEjh) for more info.
+Check out [Revenue Sharing](revenue-sharing-faq.md) for more info.

--- a/earn/earn-faq/farming-faq.md
+++ b/earn/earn-faq/farming-faq.md
@@ -111,7 +111,7 @@ An individual farm will receive CAKE emissions based on:
 
 `CAKE per block/second = C / B * A`
 
-The above numbers can be found in each of the [MasterChef](/broken/pages/-MeTWzQOSmb1ej51HT0I) contracts.
+The above numbers can be found in each of the [MasterChef](https://developer.pancakeswap.finance/contracts/masterchef/addresses) contracts.
 
 
 

--- a/ecosystem-and-partnerships/contact-us/nft-market-applications.md
+++ b/ecosystem-and-partnerships/contact-us/nft-market-applications.md
@@ -31,4 +31,4 @@ We aim to respond to applications within a week, but due to a large number of re
 
 You can shoot us an email at info@pancakeswap.com if the above parts don't cover your questions.
 
-Please don't try to contact us via this email for [customer support](../../contact-us/customer-support.md), that's not what it's for and we won't respond: your best option for getting help with the product is via the [Telegram or Reddit community](../../contact-us/social-accounts-and-communities.md).
+Please don't try to contact us via this email for [customer support](../../welcome-to-pancakeswap/contact-us/faq/help.md), that's not what it's for and we won't respond: your best option for getting help with the product is via the [Telegram or Reddit community](../../welcome-to-pancakeswap/contact-us/social-accounts.md).

--- a/trade/pancakeswap-exchange/smart-router-v2/README.md
+++ b/trade/pancakeswap-exchange/smart-router-v2/README.md
@@ -6,7 +6,7 @@ hidden: true
 
 <figure><img src="../../../.gitbook/assets/Smart Router.png" alt=""><figcaption></figcaption></figure>
 
-PancakeSwap Smart Router is a routing algorithm that links the AMM and stableswap (BNB Chain), and the AMM and market makers (Ethereum), to provide better liquidity and pricing. It uses a smart order routing algorithm that executes trades across multiple pools to find the best price for traders. For more information on StableSwap [click here](/broken/pages/nNPogTZMxocdyFIBYbkE) and for the Market Maker integration [click here](../market-maker-integration.md).
+PancakeSwap Smart Router is a routing algorithm that links the AMM and stableswap (BNB Chain), and the AMM and market makers (Ethereum), to provide better liquidity and pricing. It uses a smart order routing algorithm that executes trades across multiple pools to find the best price for traders. For more information on StableSwap [click here](../../stableswap/classic-stableswap.md) and for the Market Maker integration [click here](../market-maker-integration.md).
 
 The Kitchen will gradually roll out StableSwap pairs to further test and improve the product.
 

--- a/trade/pancakeswap-exchange/trade-guide.md
+++ b/trade/pancakeswap-exchange/trade-guide.md
@@ -64,7 +64,7 @@ Smart Router is now the default route for PancakeSwap Exchange V3. However, user
 
 To learn more about how to customize your trade routes, [click here](fees-and-routes.md).&#x20;
 
-For more information on StableSwap, [click here](/broken/pages/nNPogTZMxocdyFIBYbkE), and for the Market Maker integration, [click here](market-maker-integration.md).
+For more information on StableSwap, [click here](../stableswap/classic-stableswap.md), and for the Market Maker integration, [click here](market-maker-integration.md).
 
 ## FAQ
 

--- a/welcome-to-pancakeswap/contact-us/business-partnerships/initial-farm-offerings-ifos.md
+++ b/welcome-to-pancakeswap/contact-us/business-partnerships/initial-farm-offerings-ifos.md
@@ -22,7 +22,7 @@ For more information about our token launchpad offerings (“[Initial Farm Offer
    * An interactive session with our community to clarify any questions and establish ✨vibes✨
 5. IFO Launch
    * We will launch the IFO, and through our team of community admins, we will monitor, collate, and communicate any feedback raised by the community
-   * We will also publish some marketing materials on our [Twitter](https://app.gitbook.com/o/-MHRKTpKSfYQBsO7YgOo/s/fxRem6Hv7x6dAU7rlR7a/) and [Telegram](https://t.me/PancakeSwapAnn/6131)
+   * We will also publish some marketing materials on our [Twitter](https://x.com/PancakeSwap) and [Telegram](https://t.me/PancakeSwapAnn/6131)
 6. Post-Launch
    * We will continue to stay in touch, and work together wherever possible!&#x20;
 

--- a/welcome-to-pancakeswap/contact-us/faq/README.md
+++ b/welcome-to-pancakeswap/contact-us/faq/README.md
@@ -9,7 +9,7 @@ See for yourself:
 * Check out [these PancakeSwap security audits](../../../#is-pancakeswap-safe)
 * Transparent:
   * We’re built on open-source software: our site and all our Smart Contracts are publicly visible for maximum transparency.
-  * Our contracts are verified on blockchain explorers, so you know that what you see is what you get. Check them out [here](/broken/pages/-MeTcIwNOfhTYrz1V3xJ).
+  * Our contracts are verified on blockchain explorers, so you know that what you see is what you get. Check them out [here](https://developer.pancakeswap.finance/).
 * Security best practices:
   * The chefs use multisig for all contracts.
   * Our contracts’ time-lock gives you peace of mind.

--- a/welcome-to-pancakeswap/contact-us/faq/troubleshooting.md
+++ b/welcome-to-pancakeswap/contact-us/faq/troubleshooting.md
@@ -324,7 +324,7 @@ This error tends to appear when you're trying to unstake from an old Syrup Pool,
 
 ## **Issues with Prediction**
 
-Check [Broken link](/broken/pages/8zN9xzaYD1DvxZvzLzug "mention")
+Check [Prediction FAQ](../../../play/prediction/prediction-faq.md "mention")
 
 ## **Other issues**
 


### PR DESCRIPTION
## Documentation Sync — 2026-08-17 (auto-applied)

Generated automatically by the doc-sync cloud routine. All changes below were applied without a human gate — please review before merging.

### Low-risk fixes (typos, broken links, formatting)

- `welcome-to-pancakeswap/contact-us/business-partnerships/initial-farm-offerings-ifos.md`: "Twitter" link text pointed to an internal GitBook editor URL (`app.gitbook.com/o/.../s/...`) instead of an actual X/Twitter URL → fixed to `https://x.com/PancakeSwap` (matches the `social-accounts.md` canonical X link).
- 9 confirmed GitBook `broken-reference` links (`/broken/pages/<id>`) fixed to their correct current targets, resolved by matching link text/context against existing pages:
  - `earn/cake-staking/syrup-pool/README.md` — "CAKE Syrup Pool" contract link → `https://developer.pancakeswap.finance/contracts/syrup-pools`
  - `earn/earn-faq/farming-faq.md` — "MasterChef" contracts link → `https://developer.pancakeswap.finance/contracts/masterchef/addresses`
  - `earn/earn-faq/cake-staking-faq/vecake-faq.md` (2 occurrences + 1 content-ref block) — "Revenue Sharing" link → `revenue-sharing-faq.md` (existing sibling page)
  - `welcome-to-pancakeswap/contact-us/faq/README.md` — "contracts verified on blockchain explorers" link → `https://developer.pancakeswap.finance/`
  - `welcome-to-pancakeswap/contact-us/faq/troubleshooting.md` — "Issues with Prediction" mention link → `../../../play/prediction/prediction-faq.md`
  - `trade/pancakeswap-exchange/trade-guide.md` and `trade/pancakeswap-exchange/smart-router-v2/README.md` — "StableSwap" info link (same broken page ID in both files) → `trade/stableswap/classic-stableswap.md`
  - `ecosystem-and-partnerships/contact-us/nft-market-applications.md` — "customer support" and "Telegram or Reddit community" links pointed to non-existent `contact-us/customer-support.md` and `contact-us/social-accounts-and-communities.md` (wrong relative path, and the latter file doesn't exist under that name anywhere in the repo) → fixed to the actual existing pages `welcome-to-pancakeswap/contact-us/faq/help.md` and `welcome-to-pancakeswap/contact-us/social-accounts.md`

### High-risk fixes (synced from codebase)

- `bridge/bridging/README.md` — "Chains Currently Supported" list for the Bridge tool was missing **Solana**, even though the same page's "CAKE, a multichain token" section already lists Solana, and the frontend's Bridge/Swap code (`apps/web/src/views/Swap/Bridge/*`, `useEVMToSolanaBridgeCalldata.tsx`, `SolanaBridgeTradingFee.tsx`, `packages/canonical-bridge`) has extensive dedicated Solana-bridge support. Added "Solana" to the list.

### Source verification

- Solana bridge support: `pancake-frontend` `apps/web/src/views/Swap/Bridge/hooks/useBridgeAvailableRoutes.ts`, `useEVMToSolanaBridgeCalldata.tsx`, `apps/web/src/views/BridgeView.tsx` (all reference `NonEVMChainId.SOLANA` / `isSolana(...)` throughout the bridge flow), plus `packages/canonical-bridge/src/views/index.tsx` (`// enable Solana`).
- Contract/address links routed to `developer.pancakeswap.finance` follow the existing pattern already used elsewhere in this repo (e.g. `protocol/developers/README.md`, `trade/trading-faq/pancakeswap-infinity-faq.md`).
- `revenue-sharing-faq.md`, `classic-stableswap.md`, `play/prediction/prediction-faq.md`, `welcome-to-pancakeswap/contact-us/faq/help.md`, and `welcome-to-pancakeswap/contact-us/social-accounts.md` all verified to exist at the given paths in this repo.

### Needs reviewer decision (genuinely undecidable from sources)

Two more `/broken/pages/...` references remain unresolved because the link text gives no unambiguous current target (likely an external application form / Notion link, not a page in this repo):
- `welcome-to-pancakeswap/vecake-sunset/gauges-voting/incentivizing-liquidity.md` — "please visit here" (content-ref) for projects to incentivize liquidity via veCAKE.
- `earn/yield-farming/farming-on-aptos/faq.md` — "this guide" for projects incentivizing liquidity of their token on Aptos.

Additionally, ~9 more `/broken/pages/...` links exist under `archive/` (legacy/sunset features: Pancake Profile, NFT Market, Mini-Program). These reference products that appear fully discontinued with no current replacement page in this repo, so no safe fix target exists — left as-is pending a product decision on whether to remove the dead links or add a "discontinued" note.

### Scope note

This run's source-repo verification was limited to `pancake-frontend` — this session's GitHub access does not extend to `infinity-core`, `infinity-periphery`, `pancake-v3-contracts`, `pancake-subgraph`, `pancake-contracts-move`, `infinity-universal-router`, or `pancake-smart-contracts`, so contract-address tables sourced from those repos (v2/v3 factory addresses, subgraph deployment IDs, etc.) were spot-checked only where mirrored in `pancake-frontend` (e.g. v3 addresses, including the new Robinhood chain — verified accurate, no drift) and otherwise not re-verified this run.

### Pages scanned (no drift)

- `developer.pancakeswap.finance` chain/address cross-check: `packages/chains/src/chainId.ts` (ChainId, SunsetChainId, NonEVMChainId) — all active/sunset chains already correctly reflected across scanned pages (Monad, Robinhood both already documented).
- `pancake-developer` `contracts/v3/addresses.md` — fully verified against `packages/v3-sdk/src/constants.ts` and `packages/chains/src/chains/robinhood.ts`, including the newly-added Robinhood chain. No drift found.

---
Auto-generated by doc-sync routine. @ChefEric @chef-miso please review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FQnygHGdkYMqH2ztBKRBop)_