### PR TITLE
docs: sync with codebase (2026-08-24)

### DIFF
--- a/bridge/bridging/README.md
+++ b/bridge/bridging/README.md
@@ -29,7 +29,7 @@ Here are some reasons you may want to bridge:
 
 ## CAKE, a multichain token
 
-With our multichain expansion and deployment, CAKE is now a multichain token that is native to BNB Chain, but also available across Base, Arbitrum, Solana, Ethereum, ZKsync, Linea, opBNB, and Aptos.
+With our multichain expansion and deployment, CAKE is now a multichain token that is native to BNB Chain, but also available across Base, Arbitrum, Solana, Ethereum, ZKsync, Linea, opBNB, Monad, and Aptos.
 
 CAKE on any of the other chains is equal to CAKE on BNB Smart Chain. It can always be bridged between these chains at a 1:1 ratio and without any fee in CAKE.
 
@@ -67,6 +67,7 @@ We currently integrate with:
 * LayerZero
 * Stargate
 * Meson
+* Mayan
 
 > Note: Each provider has different bridging mechanics, supported chains, fees, and limits.
 
@@ -198,4 +199,6 @@ If a transaction is stuck for a long time, check the relevant explorer or reach 
    * `cakeOFT`: `0x3055913c90Fcc1A6CE9a358911721eEb942013A1` ([link](https://basescan.org/address/0x3055913c90Fcc1A6CE9a358911721eEb942013A1#code))
 8. **opBNB**
    * `cakeOFT`: `0x2779106e4F4A8A28d77A24c18283651a2AE22D1C` ([link](https://opbnbscan.com/address/0x2779106e4F4A8A28d77A24c18283651a2AE22D1C?tab=Contract\&p=1))
+9. **Solana**
+   * `cakeOFT`: `4qQeZ5LwSz6HuupUu8jCtgXyW1mYQcNbFAW1sWZp89HL`
 

--- a/earn/earn-faq/cake-staking-faq/cake-syrup-pool-faq.md
+++ b/earn/earn-faq/cake-staking-faq/cake-syrup-pool-faq.md
@@ -8,7 +8,7 @@ hidden: true
 
 ### What lock duration can we choose?
 
-You can choose from 1-52 weeks. What do you prefer?
+You can choose from 1 week up to 4 years.
 
 ### What variables affect the new CAKE Syrup Pool yield %s (Flexible and Fixed-Term Staking options)?
 

--- a/earn/earn-faq/farming-faq.md
+++ b/earn/earn-faq/farming-faq.md
@@ -117,6 +117,4 @@ The above numbers can be found in each of the [MasterChef](https://developer.pan
 
 ### Can I use bCAKE in v3 Farms?
 
-Yes
-
-bCAKE for V3 Farms will come very soon after the deployment of PancakeSwap Farm V3. Stay tuned.
+Yes.

--- a/guides/how-to-trade-on-the-pancakeswap-exchange.md
+++ b/guides/how-to-trade-on-the-pancakeswap-exchange.md
@@ -2,7 +2,7 @@
 
 ![Image for post](https://miro.medium.com/max/1400/0*C0Ng5_d1hK28qMMh)
 
-1. Go to the exchange page [here](https://exchange.pancakeswap.finance/#/swap).
+1. Go to the exchange page [here](https://pancakeswap.finance/swap).
 
 
 

--- a/guides/how-to-yield-farm-on-pancakeswap.md
+++ b/guides/how-to-yield-farm-on-pancakeswap.md
@@ -22,7 +22,7 @@
 
 ![](https://lh4.googleusercontent.com/Hd3RrSXeCp1Al-uoB6Aa1WO--KPZjnc6VBABhRa0IiROKE66kBFcn8yMELwAOJI5dakVQoCjMqi-RDmP3VLKlSpdS9R3QPy8Qt3x0K2wDmyhFXex142TiGPVRd23jXrn5JKkoHQ8)
 
-**4. Go to the exchange page** [**here**](https://exchange.pancakeswap.finance/?_gl=1*rbtvb8*_ga*MTUzNDEzNDQxMy4xNjAwNzkzNDM4*_ga_334KNG3DMQ*MTYwNDA2MDUwMS40OC4xLjE2MDQwNjU0NTIuMA..#/swap) **and click “Pool” and then “Add Liquidity”.**
+**4. Go to the exchange page** [**here**](https://pancakeswap.finance/swap) **and click “Pool” and then “Add Liquidity”.**
 
 \*\*\*\*
 

--- a/guides/untitled.md
+++ b/guides/untitled.md
@@ -1,4 +1,4 @@
 # How to use MetaMask on PancakeSwap
 
-[Full BNB Smart Chain wallet guides here](https://docs.binance.org/smart-chain/wallet/metamask.html)
+[Full BNB Smart Chain wallet guides here](https://docs.bnbchain.org/)
 

--- a/play/lottery/README.md
+++ b/play/lottery/README.md
@@ -15,7 +15,7 @@ Playing the PancakeSwap Lottery gives you a chance to win huge CAKE prizes! It's
 
 Lottery ticket prices are set at the start of the new lottery round, and target $5 USD (may vary slightly with sudden price fluctuations).
 
-Buying multiple Lottery tickets at once gives a bulk discount on your purchase. You can buy as many as 100 tickets in one purchase, with the discount starting small at 2 tickets, and scaling up to 10% at 100 tickets.
+Buying multiple Lottery tickets at once gives a bulk discount on your purchase. You can buy as many as 100 tickets in one purchase, with the discount starting small at 2 tickets, and scaling up to almost 5% (4.95%) at 100 tickets.
 
 ![](<../../.gitbook/assets/Screenshot 2024-08-22 at 9.59.52 PM.png>)
 

--- a/play/lottery/lottery-guide.md
+++ b/play/lottery/lottery-guide.md
@@ -5,7 +5,7 @@
 PancakeSwap's Lottery is not only a good way to make stacks of CAKE, it's also loads of fun! This guide will walk you through getting involved in the Lottery.
 
 {% hint style="info" %}
-The Lottery has changed a little since its first iteration. Lottery v2 lets you win more often, have some control over your tickets, and has more potential for huge CAKE jackpots to get your mouth watering. Learn more about [PancakeSwap Lottery v2 here](https://docs.pancakeswap.finance/products/lottery).
+The Lottery has changed a little since its first iteration. Lottery v2 lets you win more often, have some control over your tickets, and has more potential for huge CAKE jackpots to get your mouth watering. Learn more about [PancakeSwap Lottery v2 here](https://docs.pancakeswap.finance/play/lottery).
 {% endhint %}
 
 ## Deciding if you'd like to enter a round

--- a/play/prediction/README.md
+++ b/play/prediction/README.md
@@ -15,7 +15,7 @@ You can play PancakeSwap Prediction on:
 
 ### Summary: How It Works
 
-1. **Choose an asset to bet on**: Currently available on **BNB Chain**, **zkSync Era**, and **Arbitrum One**.
+1. **Choose an asset to bet on**: Currently available on **BNB Chain**; markets on **zkSync Era** and **Arbitrum One** are temporarily paused.
 2. **Pick UP or DOWN**: Predict if the asset price will be higher or lower when the “LIVE” phase ends (each round = 5 minutes).
 3. Place your bet amount: Any BNB amount
 4. **Lock in your position**: Once placed, your bet cannot be changed.
@@ -25,7 +25,7 @@ You can play PancakeSwap Prediction on:
 
 ### Mechanics & Fees
 
-* **Supported Chains: BNB Chain, zkSync Era, Arbitrum One**
+* **Supported Chains: BNB Chain (live); zkSync Era, Arbitrum One (paused)**
 * **Round frequency**: Every **5 minutes** (rolling rounds).
 * **Participation fee**: **3%** of each round’s total prize pool, a portion of which goes to **CAKE buybacks**.
 * **Winnings**: Claim anytime after results are finalized.

--- a/play/prediction/prediction-faq.md
+++ b/play/prediction/prediction-faq.md
@@ -147,7 +147,7 @@ You might be able to claim your winnings directly from the contract. Follow the 
 {% tab title="Check rounds you played" %}
 How to check the history of rounds you played
 
-1. Go to BscScan page of the [Prediction contract](https://bscscan.com/address/0x0E3A8078EDD2021dadcdE733C6b4a86E51EE8f07#readContract) (e.g. BNBUSD).
+1. Go to BscScan page of the [Prediction contract](https://bscscan.com/address/0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA#readContract) (e.g. BNBUSD).
 2. Scroll down to “8. getUserRounds”.
 3. Type in your wallet address under “user(address)”.
 4. Set “cursor(uint256)" to 0 and “size(uint256)" to 1000.
@@ -158,7 +158,7 @@ How to check the history of rounds you played
 {% tab title="Check if you can claim" %}
 First, check whether you should actually be able to claim from the round you played.
 
-1. Go to BscScan page of the [Prediction contract](https://bscscan.com/address/0x0E3A8078EDD2021dadcdE733C6b4a86E51EE8f07#readContract) (e.g. BNBUSD), and go to the Read tab
+1. Go to BscScan page of the [Prediction contract](https://bscscan.com/address/0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA#readContract) (e.g. BNBUSD), and go to the Read tab
 2. Scroll down to “4. claimable”.
 3. Type in the round id you want to check under "epoch(uint256)”.
 4. Type in your wallet address under “user(address)”.
@@ -171,7 +171,7 @@ First, check whether you should actually be able to claim from the round you pla
 {% tab title="Claim from a round" %}
 How to claim
 
-1. Go to BscScan page of the [Prediction contract](https://bscscan.com/address/0x0E3A8078EDD2021dadcdE733C6b4a86E51EE8f07#readContract) (e.g. BNBUSD), and go to the Write tab
+1. Go to BscScan page of the [Prediction contract](https://bscscan.com/address/0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA#readContract) (e.g. BNBUSD), and go to the Write tab
 2. Tap “🔴 Connect to Web3”
 3. Use MetaMask or WalletConnect to connect.
 4. Scroll down to “3. claim”

--- a/trade/pancakeswap-infinity/pool-types/README.md
+++ b/trade/pancakeswap-infinity/pool-types/README.md
@@ -6,5 +6,5 @@
 
 Infinity currently supports the following pool types:
 
-* [Infinity CLAMM & LBAMM](https://docs.pancakeswap.finance/~/revisions/dR1OpdERU6eEn0BRwIs6/trade/pancakeswap-infinity/pool-types/infinity-clamm-and-lbamm)
-* [Infinity StableSwap](https://docs.pancakeswap.finance/~/revisions/dR1OpdERU6eEn0BRwIs6/trade/stableswap/infinity-stableswap)
+* [Infinity CLAMM & LBAMM](infinity-clamm-and-lbamm.md)
+* [Infinity StableSwap](../../stableswap/infinity-stableswap.md)

--- a/trade/pancakeswap-infinity/pool-types/infinity-clamm-and-lbamm.md
+++ b/trade/pancakeswap-infinity/pool-types/infinity-clamm-and-lbamm.md
@@ -70,7 +70,7 @@ Dynamic fees offer maximum flexibility and optimize fee structures for both LPs 
 | ---------------- | ---------------- |
 | 1%               | 0.33%            |
 | 2%               | 0.4% (capped)    |
-| Dynamic Fee Pool | 0%               |
+| Dynamic Fee Pool | 0.03% (current default) |
 
 #### 🛠️ Setup Notes for Pool Creators
 

--- a/trade/pancakeswap-infinity/pool-types/infinity-stableswap.md
+++ b/trade/pancakeswap-infinity/pool-types/infinity-stableswap.md
@@ -10,4 +10,4 @@ It uses a StableSwap invariant designed to:
 
 
 
-👉 Learn more about pool mechanics and pool creation [here](https://docs.pancakeswap.finance/~/revisions/E5nc3XhgBcYotE6q89fB/trade/stableswap/infinity-stableswap).
+👉 Learn more about pool mechanics and pool creation [here](../../stableswap/infinity-stableswap.md).

--- a/trade/pancakeswap-x/README.md
+++ b/trade/pancakeswap-x/README.md
@@ -8,7 +8,7 @@ PancakeSwap X introduces a whole new way to trade your favourite assets on Panca
 * Gas-free swaps
 
 {% hint style="success" %}
-**PancakeSwap X is live on Arbitrum, Ethereum, and Base, supporting crypto tokens, and on BNB Chain, it supports real-world assets (RWAs) only.**
+**PancakeSwap X is live on Arbitrum, Ethereum, BNB Chain, Base, and Robinhood Chain, supporting crypto token swaps. Real-world assets (RWAs) are additionally supported on BNB Chain, Ethereum, and Robinhood Chain.**
 {% endhint %}
 
 > **Looking to integrate? Check out the technical guide for PancakeSwap X integration** [**here**](https://www.notion.so/PCSX-Tech-Integration-Guide-0eb33e93295644e9855ec2c34b58b0c4?source=copy_link)**.**

--- a/trade/pancakeswap-x/faqs.md
+++ b/trade/pancakeswap-x/faqs.md
@@ -2,7 +2,7 @@
 
 #### Which network is currently supported?
 
-PancakeSwap X is live on Arbitrum and Ethereum, supporting crypto tokens, and on BNB Chain, it supports real-world assets (RWAs) like tokenised stocks, bonds, and ETFs.
+PancakeSwap X is live on Arbitrum, Ethereum, BNB Chain, Base, and Robinhood Chain, supporting crypto token swaps. Real-world assets (RWAs) like tokenised stocks, bonds, and ETFs are additionally supported on BNB Chain, Ethereum, and Robinhood Chain.
 
 #### Is PancakeSwap X on by default?
 

--- a/trade/pancakeswap-x/rwas.md
+++ b/trade/pancakeswap-x/rwas.md
@@ -1,6 +1,6 @@
 # RWAs
 
-PancakeSwap X supports real-world assets onchain to BNB Chain at scale. Users can trade 100+ tokenized stocks, bonds and ETFs directly on PancakeSwap powered by Ondo Finance.
+PancakeSwap supports real-world assets onchain across BNB Chain, Ethereum, and Robinhood Chain at scale, with RWA trading also available on Solana. Users can trade 100+ tokenized stocks, bonds and ETFs directly on PancakeSwap, powered by Ondo Finance and other issuers.
 
 ### What is Ondo Finance?
 

--- a/trade/perpetual-trading/perpetuals-trading-new/perpetual-trading-faq.md
+++ b/trade/perpetual-trading/perpetuals-trading-new/perpetual-trading-faq.md
@@ -61,4 +61,4 @@ Fees for PancakeSwap Perpetuals as follows:
 
 ### **Which jurisdictions are restricted from using the product?** <a href="#whats-the-difference-between-a-maker-and-taker-order" id="whats-the-difference-between-a-maker-and-taker-order"></a>
 
-Users located in or accessing the service from the United States of America, Canada, the United Kingdom, China, North Korea, Russia, Ukraine, Cuba, Iran, Venezuela, or Syria are not permitted to use the product. Access may be restricted or blocked in accordance with applicable compliance and regulatory requirements.
+Users located in or accessing the service from the United States of America, Canada, the United Kingdom, China, North Korea, South Korea, Russia, Ukraine, Cuba, Iran, Venezuela, or Syria are not permitted to use the product. Access may be restricted or blocked in accordance with applicable compliance and regulatory requirements.

--- a/trade/stableswap/README.md
+++ b/trade/stableswap/README.md
@@ -6,7 +6,7 @@ StableSwap on PancakeSwap is a feature to trade stable pairs with a lower slippa
 
 
 
-PancakeSwap currently offers two StableSwap models: [**Infinity StableSwap**](https://docs.pancakeswap.finance/~/revisions/4JQRJCuMPHEJgYdxdVME/trade/stableswap/infinity-stableswap) and [**Classic StableSwap**](https://docs.pancakeswap.finance/~/revisions/4JQRJCuMPHEJgYdxdVME/trade/stableswap/classic-stableswap). Infinity StableSwap is built on PancakeSwap’s latest Infinity architecture, offering improved flexibility, efficiency, and future extensibility. Classic StableSwap refers to the original StableSwap implementation, which continues to support existing pools and liquidity.
+PancakeSwap currently offers two StableSwap models: [**Infinity StableSwap**](infinity-stableswap.md) and [**Classic StableSwap**](classic-stableswap.md). Infinity StableSwap is built on PancakeSwap’s latest Infinity architecture, offering improved flexibility, efficiency, and future extensibility. Classic StableSwap refers to the original StableSwap implementation, which continues to support existing pools and liquidity.
 
 
 

--- a/trading-tools/pancake-gifts/README.md
+++ b/trading-tools/pancake-gifts/README.md
@@ -92,4 +92,4 @@ Gifts follow a defined lifecycle based on status and time:
    * Retries will be attempted upon first unsuccessful claim.
    * If still unsuccessful:
      * Recipient sees “Unclaimable”
-     * Sender must manually cancel the gift to retrieve funds and receipient will have to request or a new gift code.
+     * Sender must manually cancel the gift to retrieve funds and the recipient will have to request a new gift code.

--- a/trading-tools/pancake-gifts/pancake-gifts-faq.md
+++ b/trading-tools/pancake-gifts/pancake-gifts-faq.md
@@ -39,7 +39,7 @@ Yes:
 * QR code also embeds the gift code, but **cannot be regenerated later.**&#x20;
 
 {% hint style="success" %}
-**Pro Tip:**  Download the image once its generated
+**Pro Tip:** Download the image once it's generated
 {% endhint %}
 
 * Manual claims require the actual gift code — no fallback if the link/QR is lost

--- a/trading-tools/pancakeswap-auto-slippage/README.md
+++ b/trading-tools/pancakeswap-auto-slippage/README.md
@@ -8,7 +8,7 @@ PancakeSwap has introduced Auto Slippage to make trading easier and more efficie
 
 * Market volatility – Prices can move quickly between when you place and confirm
 * Low liquidity – there aren’t enough tokens available at your expected price
-* Blockchain delays – confirmation times can cause the price to change before the trade is completed finalized
+* Blockchain delays – confirmation times can cause the price to change before the trade is finalized
 
 {% hint style="info" %}
 Example:
@@ -26,7 +26,7 @@ Example:
 If you set a 1% slippage tolerance and the price changes by more than 1% before the trade is completed, the trade won’t go through.
 {% endhint %}
 
-## What happens if my Slippage Tolernace is too low?
+## What happens if my Slippage Tolerance is too low?
 
 If your slippage tolerance is **set too low**, there’s a higher chance your transaction will fail — especially when:
 

--- a/welcome-to-pancakeswap/about-us/brand.md
+++ b/welcome-to-pancakeswap/about-us/brand.md
@@ -1,5 +1,5 @@
 ---
-description: Guidlines and downloadable assets like the PancakeSwap logo SVG
+description: Guidelines and downloadable assets like the PancakeSwap logo SVG
 ---
 
 # Brand & Logos

--- a/welcome-to-pancakeswap/contact-us/ambassador-program/benefits-of-a-pancakeswap-ambassador.md
+++ b/welcome-to-pancakeswap/contact-us/ambassador-program/benefits-of-a-pancakeswap-ambassador.md
@@ -1,4 +1,4 @@
-# Benefits of  a PancakeSwap Ambassador
+# Benefits of a PancakeSwap Ambassador
 
 ### **Global Recognition**
 

--- a/welcome-to-pancakeswap/contact-us/business-partnerships/initial-farm-offerings-ifos.md
+++ b/welcome-to-pancakeswap/contact-us/business-partnerships/initial-farm-offerings-ifos.md
@@ -1,6 +1,6 @@
 # 🧑‍🌾 Initial Farm Offerings - IFOs
 
-For more information about our token launchpad offerings (“[Initial Farm Offering, or IFO”](https://pancakeswap.finance/ifo)), please view this PDF
+For more information about our token launchpad offerings (“[Initial Farm Offering, or IFO](https://pancakeswap.finance/ifo)”), please view this PDF
 
 {% file src="../../../.gitbook/assets/PancakeSwap IFO One-Pager.pdf" %}
 

--- a/welcome-to-pancakeswap/contact-us/faq/troubleshooting.md
+++ b/welcome-to-pancakeswap/contact-us/faq/troubleshooting.md
@@ -305,7 +305,7 @@ Firstly,[ let the team know](../social-accounts.md) which pool you're trying to 
 You can perform an “emergencyWithdraw” from the contract directly to unstake your staked tokens.
 
 1. Find the contract address of the Syrup Pool you're trying to unstake from. You can find it in your wallet's transaction log.
-2. Go to [https://bscscan.com/](https://bscscan.com/address/0x73feaa1eE314F8c655E354234017bE2193C9E24E#writeContract) and in the search bar, enter the contract address.
+2. Go to [https://bscscan.com/](https://bscscan.com/) and in the search bar, enter the contract address.
 3. Select **Write Contract.**
 4. Click **“Connect to Web3”** and connect your wallet.![](https://lh6.googleusercontent.com/-_sNkO1gcOOJXkduDEUzbExKE2mNxBOR0f86Lpp3BBuPbIcmAHsfuvpF-hKqRn4oID5QzdGkk_1dTHkPuCmE50vpNNZxEqoM5nPmE_12k3-8Q8YYoRYqJ_VGjxJ03YPRuVQ1O5ME)
 5. In section **“3. emergencyWithdraw”,** and click “Write”.

--- a/welcome-to-pancakeswap/contact-us/faq/unsticking-a-transaction-stuck-as-pending-with-metamask.md
+++ b/welcome-to-pancakeswap/contact-us/faq/unsticking-a-transaction-stuck-as-pending-with-metamask.md
@@ -42,11 +42,11 @@ We’re now going to find the transaction that’s stuck, and make a note of the
 
 ![](https://lh5.googleusercontent.com/9qVjhK1kEKDL8l4TTdOFo4o547PDIIeQpCCY18gPyaUFJrpFbyYhMfBQ1CRzjjrllgrcqVbwkhxKCZBNlIad8J1yCpMVhsBKjIAcwfsQHQb7jnl2RD2ufQU-zNEn2Hn2g4LGvYDU)
 
-6\. In the token’s menu, find your **Pending** transaction in the Queue area. Click on your transaction for more details.
+7\. In the token’s menu, find your **Pending** transaction in the Queue area. Click on your transaction for more details.
 
 ![](https://lh4.googleusercontent.com/HMd5iKjIvm-f7Xi7xtecTsq56x1i15GjUkwCm5Z_83xMfOXDd2jabcCDyUwELf51IHseEeCk2WnvWfHwTSUlFnLAJrmjkkOfm_fA5fimgdABnYfdjmBxxst8TOaUJUhc2iO_CN-k)
 
-7\. Look for the **Nonce** entry, and take note of this number.
+8\. Look for the **Nonce** entry, and take note of this number.
 
 ### **3. Overwrite the Stuck Transaction**
 
@@ -54,20 +54,20 @@ Now we’re going to make a new transaction to replace the stuck one. We’ll cu
 
 ![](<../../../.gitbook/assets/image (176).png>)
 
-8\. Create a new transaction to replace your stuck transaction. This time around, increase the **Transaction Fee**. Here we’ve increased it from 9 to 20. This will make it more likely for your transaction to be added to a block.
+9\. Create a new transaction to replace your stuck transaction. This time around, increase the **Transaction Fee**. Here we’ve increased it from 9 to 20. This will make it more likely for your transaction to be added to a block.
 
 ![](<../../../.gitbook/assets/image (34).png>)
 
-9\. On the confirmation page, make sure your Gas Price is now at your new, higher amount.
+10\. On the confirmation page, make sure your Gas Price is now at your new, higher amount.
 
-10\. Find the **CUSTOM NONCE** entry and change the nonce to the number you wrote down in step 7. Now click Confirm.
+11\. Find the **CUSTOM NONCE** entry and change the nonce to the number you wrote down in step 8. Now click Confirm.
 
 ![](https://lh6.googleusercontent.com/PYhYm2ro0SVzerBo5qguFIPOYl0DjLSfl0JT8UdfN3T4i-0hjBq-CQvr-UA0bSyG-ZndrWmLGptfZUcnGBlvUk118GGZn7ciDNaC4hmfovH9v_M5XMIYmkAmB-Fr-6TTpYnnDX1p)
 
-11\. Your new transaction should now be accepted into a block. To check, open MetaMask and click the **Activity** tab.
+12\. Your new transaction should now be accepted into a block. To check, open MetaMask and click the **Activity** tab.
 
 ![](https://lh6.googleusercontent.com/Iw3e0YP4ORhPgw8-MNxvzlDlfgG5nD226P4ixiziPC_9j3_LfU3o1-_LA2yDmegbRw5x9Sgk3RACFJJkyJDrFJA1j2J93H21uGhhWabkdDQUHsU_oVdkZVQTTWaQPzXHAWClpsb4)
 
-12\. Your completed transaction should show at the top of your Activity list. If it still says “Pending” in orange you’ll need to wait a little longer, or try the process again with an even higher transaction fee (gas price).
+13\. Your completed transaction should show at the top of your Activity list. If it still says “Pending” in orange you’ll need to wait a little longer, or try the process again with an even higher transaction fee (gas price).
 
 Since no wallet can create two transactions of the same nonce, if the replacement transaction you make is successful, your stuck transaction will be canceled.<br>

--- a/welcome-to-pancakeswap/how-to-guides/get-started-monad/create-a-wallet-monad.md
+++ b/welcome-to-pancakeswap/how-to-guides/get-started-monad/create-a-wallet-monad.md
@@ -43,7 +43,7 @@ Not sure which type of wallet to use? Here’s a quick breakdown of mobile vs. d
 ***
 
 {% hint style="success" %}
-**Some popular** [**wallets**](https://docs.monad.xyz/tooling-and-infra/wallets/software-wallets) **that you may use for Monad ecoystem!**
+**Some popular** [**wallets**](https://docs.monad.xyz/tooling-and-infra/wallets/software-wallets) **that you may use for the Monad ecosystem!**
 {% endhint %}
 
 ***

--- a/welcome-to-pancakeswap/how-to-guides/get-started-monad/get-mon-on-monad.md
+++ b/welcome-to-pancakeswap/how-to-guides/get-started-monad/get-mon-on-monad.md
@@ -70,7 +70,7 @@ This is a user-friendly option for mobile-first users who want to skip setting u
 
 #### IV. **Bridge MON from Another Blockchain**
 
-Already have tokens on a different chain like **BNB Chain**, **Ethereum**, or **Base**? You can bring funds over to Solana using **bridging platforms**.
+Already have tokens on a different chain like **BNB Chain**, **Ethereum**, or **Base**? You can bring funds over to Monad using **bridging platforms**.
 
 #### ✅ What you do:
 

--- a/welcome-to-pancakeswap/how-to-guides/get-started-sol/README.md
+++ b/welcome-to-pancakeswap/how-to-guides/get-started-sol/README.md
@@ -11,7 +11,7 @@ Using anything new can be a bit of a challenge. Don't worry though, we've create
 Follow these guides to get everything set up to use PancakeSwap, or feel free to jump to the guide you need if you've been doing okay but lost your way.
 
 * [Create a wallet (SOL)](https://docs.pancakeswap.finance/welcome-to-pancakeswap/how-to-guides/get-started-sol/create-a-wallet-sol)
-* [Get SOL](https://docs.pancakeswap.finance/welcome-to-pancakeswap/how-to-guides/get-started-aptos/get-sol)
+* [Get SOL](https://docs.pancakeswap.finance/welcome-to-pancakeswap/how-to-guides/get-started-sol/get-sol)
 * [Solana FAQ](https://docs.pancakeswap.finance/welcome-to-pancakeswap/how-to-guides/get-started-sol/solana-faq)
 
 If you can't find what you need, feel free to visit the [PancakeSwap Telegram](../../contact-us/social-accounts.md) and ask for help there!

--- a/welcome-to-pancakeswap/how-to-guides/get-started/bep20-guide.md
+++ b/welcome-to-pancakeswap/how-to-guides/get-started/bep20-guide.md
@@ -20,7 +20,7 @@ This bridge allows you to seamlessly move your stablecoins over to BNB Chain, an
 {% endtab %}
 
 {% tab title="💰 Binance" %}
-[**Binance.com**](https://github.com/pancakeswap/pancake-document/tree/255db0c7af28df2f9c1209daa5cdbd774490a666/get-started/www.binance.com)
+[**Binance.com**](https://www.binance.com)
 
 You can withdraw tokens as BEP20 via your Binance account (if you have one). Bear in mind you need an account to do so.
 

--- a/welcome-to-pancakeswap/how-to-guides/get-started/connection-guide.md
+++ b/welcome-to-pancakeswap/how-to-guides/get-started/connection-guide.md
@@ -34,7 +34,7 @@ If you find you are unable to connect at step 4, go back to the DApps menu and f
 
 **iOS**
 
-To connect to PancakeSwap through iOS, Trust Wallet have prepared a detailed guide on using WallteConnect.
+To connect to PancakeSwap through iOS, Trust Wallet has prepared a detailed guide on using WalletConnect.
 
 Read the [Trust Wallet guide to connecting to PancakeSwap via WalletConnect](https://community.trustwallet.com/t/using-walletconnect-to-access-pancakeswap/212307).
 

--- a/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/how-v3-apr-is-calculated.md
+++ b/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/how-v3-apr-is-calculated.md
@@ -52,7 +52,7 @@ Global APR calculated using the total amount of active & staked liquidity with t
 APRs for individual positions may vary depend on their price range settings.
 
 $$
-ARP_p = {\frac{USD_{r}}{USD_{p}}} {\frac{L_{p}}{L_{lm}}}
+APR_p = {\frac{USD_{r}}{USD_{p}}} {\frac{L_{p}}{L_{lm}}}
 $$
 
 * $$USD_r$$: CAKE reward earn USD per year in pool

--- a/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/migrate-your-stakings.md
+++ b/welcome-to-pancakeswap/how-to-guides/v3-v2-migration/migration/migrate-your-stakings.md
@@ -102,7 +102,7 @@ Migration will take several hours, but it should be totally finished upon the la
 
 #### I don’t see the migration helper!
 
-It will only be deployed once smart contract deployments and configurations are completed. It could take serval hours. Follow our [Twitter](https://twitter.com/pancakeswap/) or [Telegram](https://t.me/PancakeSwapAnn) announcement channel for the latest updates!
+It will only be deployed once smart contract deployments and configurations are completed. It could take several hours. Follow our [Twitter](https://twitter.com/pancakeswap/) or [Telegram](https://t.me/PancakeSwapAnn) announcement channel for the latest updates!
 
 #### Why lock staking is not available?
 


### PR DESCRIPTION
## Documentation Sync — 2026-08-24 (auto-applied)

Generated automatically by the doc-sync cloud routine. Scanned against pancake-frontend (develop), infinity-core, infinity-periphery, pancake-v3-contracts, pancake-subgraph, infinity-universal-router, and pancake-smart-contracts (master). All changes below were applied without a human gate — please review before merging.

### High-risk fixes (synced from codebase)

- **trade/pancakeswap-x/{README.md,faqs.md,rwas.md}** — PCSX chain list was stale (missing BNB Chain/Base/Robinhood as general swap chains; RWA scope wrong). Now: crypto swaps on Arbitrum, Ethereum, BNB Chain, Base, Robinhood Chain; RWAs on BNB Chain, Ethereum, Robinhood Chain (+ Solana via a separate path).
  - Evidence: `pancake-frontend` `apps/web/src/config/pcsx.ts` `SUPPORTED_CHAINS`, `apps/web/src/stocks/constants.ts` `STOCKS_SUPPORTED_CHAIN_IDS`.
- **trade/pancakeswap-infinity/pool-types/{README.md,infinity-stableswap.md}**, **trade/stableswap/README.md** — internal links pointed at non-public GitBook draft-revision URLs (`~/revisions/...`). Replaced with relative page links.
- **trade/pancakeswap-infinity/pool-types/infinity-clamm-and-lbamm.md** — Dynamic Fee Pool protocol-fee default listed as 0%; actual default is 0.03%.
  - Evidence: `infinity-core` `src/ProtocolFeeController.sol` (`defaultProtocolFeeForDynamicFeePool = 300`).
- **trade/perpetual-trading/perpetuals-trading-new/perpetual-trading-faq.md** — geo-blocked jurisdiction list omitted South Korea, which is actively blocked in code.
  - Evidence: `pancake-frontend` `packages/utils/geoBlock.ts` `BLOCK_PERPS_COUNTRIES` (includes `KR`).
- **play/prediction/prediction-faq.md** (3 occurrences) — BscScan troubleshooting links pointed at the deprecated CAKE-prediction contract (`0x0E3A...`) instead of the BNBUSD contract used in the walkthrough. Fixed to `0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA`.
  - Evidence: `pancake-frontend` `packages/prediction/src/predictionContract.ts`; `pancake-developer` `contracts/prediction/addresses.mdx` confirms 0x0E3A... is listed under Deprecated.
- **play/lottery/README.md** — bulk-ticket discount at 100 tickets stated as 10%; actual is ~4.95% (matches the sibling `lottery-guide.md` and the contract's discount formula).
  - Evidence: `pancake-smart-contracts` `PancakeSwapLottery.sol` discount divisor (2000) test fixtures.
- **play/prediction/README.md** — zkSync Era and Arbitrum One prediction markets listed as live; both are currently `paused: true` in the frontend config. Annotated as paused (matching the existing CAKEUSD-paused convention on this page).
  - Evidence: `pancake-frontend` `packages/prediction/src/constants/predictions/{arb,zkSync}.ts`.
- **earn/earn-faq/cake-staking-faq/cake-syrup-pool-faq.md** — lock duration stated as "1-52 weeks"; current veCAKE max lock is 4 years, contradicting the sibling `vecake-faq.md` and the on-chain constant.
  - Evidence: `pancake-smart-contracts` `MAX_LOCK_TIME = 209 * WEEK - 1` (~4 years).

### Low-risk fixes (typos, broken links, formatting, stale chain/provider lists)

- `bridge/bridging/README.md` — added Monad to the CAKE multichain list; added Mayan to the supported bridge providers; added the Solana CAKE OFT address (was missing despite Solana being a listed bridging chain). Evidence: `pancake-frontend` `packages/tokens/src/constants/common.ts`, `packages/canonical-bridge/src/hooks/useTransferConfig.ts`, `packages/canonical-bridge/src/token-config/mainnet/layerZero/config.json`.
- `play/lottery/lottery-guide.md` — dead link `docs.pancakeswap.finance/products/lottery` → `.../play/lottery`.
- `earn/earn-faq/farming-faq.md` — removed a "coming very soon" bCAKE-for-V3-Farms promise; bCAKE has shipped (and iterated) long since.
- `guides/how-to-yield-farm-on-pancakeswap.md`, `guides/how-to-trade-on-the-pancakeswap-exchange.md` — dead `exchange.pancakeswap.finance` V1 domain (deprecated May 2021 per the docs' own FAQ) → `pancakeswap.finance/swap`.
- `guides/untitled.md` — dead `docs.binance.org` (retired BNB Chain rebrand domain) → `docs.bnbchain.org`.
- `welcome-to-pancakeswap/how-to-guides/get-started/bep20-guide.md` — "Binance.com" link pointed into this repo's own commit history instead of binance.com.
- `welcome-to-pancakeswap/how-to-guides/get-started-sol/README.md` — "Get SOL" link pointed into the Aptos guide folder instead of the Solana one.
- `welcome-to-pancakeswap/contact-us/faq/troubleshooting.md` — BscScan link carried a leftover unrelated contract address; fixed to plain bscscan.com (matches the surrounding instructions).
- Typo fixes: `trading-tools/pancake-gifts/README.md` ("receipient"→"recipient", redundant "or"), `trading-tools/pancake-gifts/pancake-gifts-faq.md` ("its"→"it's"), `trading-tools/pancakeswap-auto-slippage/README.md` ("Tolernace"→"Tolerance", "completed finalized"→"finalized"), `welcome-to-pancakeswap/about-us/brand.md` ("Guidlines"→"Guidelines"), `.../ambassador-program/benefits-of-a-pancakeswap-ambassador.md` (double space), `.../how-to-guides/get-started/connection-guide.md` ("WallteConnect"→"WalletConnect", "have"→"has"), `.../get-started-monad/create-a-wallet-monad.md` ("ecoystem"→"ecosystem"), `.../get-started-monad/get-mon-on-monad.md` ("Solana"→"Monad", copy-paste leftover), `.../v3-v2-migration/how-v3-apr-is-calculated.md` (`ARP_p`→`APR_p` in formula), `.../v3-v2-migration/migration/migrate-your-stakings.md` ("serval"→"several"), `.../business-partnerships/initial-farm-offerings-ifos.md` (quote-mark placement around a link).
- `welcome-to-pancakeswap/contact-us/faq/unsticking-a-transaction-stuck-as-pending-with-metamask.md` — a duplicated step "6." threw off numbering for the rest of the 13-step list; renumbered steps 7–13.

### Needs reviewer decision (genuinely undecidable from sources)

- `tokenomics/untitled.md`, `tokenomics/cake-updated-10-29-2020/untitled.md`, `tokenomics/syrup.md` — orphaned (not in SUMMARY.md), undated pages describing a fixed 40-CAKE/block emission model that contradicts the current `protocol/cake-tokenomics.md` (Tokenomics 3.0, 400M cap, no fixed per-block reward). A properly-archived equivalent already exists at `archive/old-tokenomics/cake-tokenomics-v1.md`. Recommend deleting these three or adding the same archival framing.
- `products/coming-soon/new-cake-pool/{README.md,fixed-term-staking.md,flexible-staking.md}` — filed under "coming-soon" but the page's own body says the product is deprecated; duplicate of the correctly-archived `archive/legacy-products/new-cake-pool/README.md`. Recommend removing this tree.
- `products/syrup-pool/how-to-stake-in-syrup-pools-with-bscscan.md`, `earn/cake-staking/syrup-pool/syrup-pool-guide.md`, `earn/earn-faq/cake-staking-faq/syrup-pool-faq.md` — describe the legacy Auto/Manual CAKE pool as the live staking flow; product copy (`apps/web/src/views/Pools/faqConfig.tsx`) calls these "legacy pools" requiring migration to veCAKE. Recommend rewriting to lead with veCAKE Flexible/Fixed-Term staking.
- `earn/cakepad/faq-users.md` (chain list: BNB/Base/ARB/ETH/Linea/opBNB) and `earn/cakepad/faq-partners.md` (BNB/Base/ARB/ETH/ZKsync/Linea/opBNB) — disagree with each other AND with code (`apps/cakepad/src/config/cakepad.config.ts` `IFO_SUPPORT_CHAINS` = BNB Chain, Base, Monad only). Needs a product decision on the intended CAKE.PAD chain set before both pages are aligned.
- `earn/cakepad/faq-users.md` anchor link to `cakepad-guide.md#ifo-with-token-vesting` — heading has since been renamed to "CAKE.PAD event with token vesting" during the IFO→CAKE.PAD rebrand; exact GitBook-generated slug not confirmed.
- `earn/yield-farming/farming-on-aptos/faq.md`, `welcome-to-pancakeswap/vecake-sunset/gauges-voting/incentivizing-liquidity.md`, and 6 pages under `archive/**` — contain literal `/broken/pages/...` GitBook broken-reference placeholders with no recoverable target; need a human to identify the correct destination or remove the link.
- `trade/perpetual-trading/perpetuals-trading-new/perpetual-trading-faq.md` — a heading's anchor `id`/`href` references a nonexistent "maker vs taker" question (leftover from an edit); needs a corrected anchor id.
- `trade/trading-faq/limit-orders-faq.md` — "Stop Limit Orders feature is coming soon" was never shipped for the (now-deprecated) Limit V2 product this FAQ describes; needs a product decision on whether to remove the promise or archive the page.
- `trade/crosschain-swaps/copy-of-swap-scenarios.md` — evident accidental duplicate of `swap-scenarios.md`, still wired into SUMMARY.md, with a stale pre-Linea/zkSync bridging matrix. Recommend deleting.
- `trade/limit-orders/how-to-use-limit-orders-1.md` — legacy Orbs-flow guide whose target URL (`pancakeswap.finance/swap/limit`) has since been repurposed for the new Infinity-based limit orders; needs retitling or removal.
- `trade/perpetual-trading/perpetual-trading-v2/degen-mode/README.md` — pair list (BTCUSD only) unverifiable; this legacy ApolloX-powered product has no code in the current frontend repo and the live app is unreachable from this sandbox.
- `trade/pancakeswap-exchange/smart-router-v2/{README.md,how-to-trade-using-smart-router.md}` — hidden legacy pages contradicting current Smart Router behavior (split routing has shipped; Smart Router is now the default). Recommend archiving.
- `bridge/bridging/wormhole-bridge-guide.md`, `bridge/faq/wormhole-bridge-faq.md` — hidden pages describing a Wormhole bridge integration; Wormhole is absent from the current provider list. Recommend confirming intentionally archived vs. deleting.
- `welcome-to-pancakeswap/vecake-sunset/README.md` — states a veCAKE redemption deadline of October 23, 2025 as upcoming guidance; that date is roughly 10 months in the past. Needs a rewrite reflecting current post-deadline status.
- `ecosystem-and-partnerships/contact-us/nft-market-applications.md` — orphaned page inviting NFT collections to list, while the NFT Marketplace itself is marked `[ARCHIVED]` elsewhere in this repo. Recommend removing.
- `welcome-to-pancakeswap/how-to-guides/get-started/connection-guide.md` and `wallet-guide.md` — link to the discontinued Binance Chain Wallet / binance.org. Needs a product decision on which current wallet to list instead.

### Pages scanned (no drift)

Full-file audits were run across `trade/**` (pancakeswap-exchange, pancakeswap-infinity, pancakeswap-x, stableswap, perpetual-trading, limit-orders, crosschain-swaps, trading-faq), `earn/**`, `bridge/**`, `play/**`, `tokenomics/**`, `products/**`, `protocol/**`, `guides/**`, `trading-tools/**`, `hiring/**`, `ecosystem-and-partnerships/**`, and `code/**` (168 files), plus ~45 of 102 `welcome-to-pancakeswap/**` files and all 43 `archive/**` files via mechanical link/typo sweeps. Most contract addresses, chain lists, and fee figures matched source exactly — only the items above showed drift.

Note: `contracts-aptos`-equivalent Aptos doc content and the `pancake-contracts-move` source repo were outside this session's repo access and were not scanned this run.

---
Auto-generated by doc-sync routine. @ChefEric @chef-miso please review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kitp5KKQFDew2Y2timBYVi)_