### PR TITLE
docs: sync with codebase (2026-08-31)

### DIFF
--- a/archive/old-tokenomics/README.md
+++ b/archive/old-tokenomics/README.md
@@ -16,7 +16,7 @@ Earn CAKE from Farms and Syrup Pools, win it in the lottery, or [buy it on the e
 * Use it in [Yield Farms](https://docs.pancakeswap.finance/products/yield-farming) to earn more CAKE
 * Buy Lottery tickets in the [PancakeSwap Lottery](../../play/lottery/)
 * Participate in [IFO Token Sales](../../earn/cakepad/)
-* Create your [Pancake Profile](/broken/pages/-MYccH_bJjPXGyPCweA8) and mint NFTs
+* Create your Pancake Profile and mint NFTs
 * [Vote on proposals](../../protocol/voting/) relating to the PancakeSwap ecosystem
 
 But that's not all -- there's much more on the horizon for CAKE!
@@ -27,10 +27,6 @@ Check below to discover the nuts and bolts of how CAKE works.
 
 {% content-ref url="../../protocol/cake-tokenomics.md" %}
 [cake-tokenomics.md](../../protocol/cake-tokenomics.md)
-{% endcontent-ref %}
-
-{% content-ref url="/broken/pages/-MLAzz7i0mcBCSvWcZbU" %}
-[Broken link](/broken/pages/-MLAzz7i0mcBCSvWcZbU)
 {% endcontent-ref %}
 
 ### \*\*\*\*

--- a/bridge/bridging/README.md
+++ b/bridge/bridging/README.md
@@ -84,6 +84,7 @@ We currently integrate with:
 * opBNB
 * ZKsync
 * Linea
+* Monad
 * Solana
 * Aptos (V1 site)
 

--- a/earn/yield-farming/farming-on-aptos/faq.md
+++ b/earn/yield-farming/farming-on-aptos/faq.md
@@ -30,6 +30,6 @@ With our multichain expansion and deployment on Aptos. CAKE is now a multichain 
 
 CAKE on Aptos is equal to CAKE on BNB Smart Chain and can always be bridged between two chains with a 1:1 ratio.&#x20;
 
-Please note that there is only one CAKE. There are no different versions of CAKE between different chains. And the total supply of CAKE across all blockchains will be capped at 750M, according to our v2 tokenomic litepaper.
+Please note that there is only one CAKE. There are no different versions of CAKE between different chains. And the total supply of CAKE across all blockchains is capped at 400M, as outlined in [this vote proposal](https://pancakeswap.finance/voting/proposal/0xc988547f7b6c435764c840623685b0c2d13ebcc91d1672d39c51b6d14207f9a5).
 
 To bridge your CAKE to BNB Smart Chain, check out the [CAKE bridging guide](../../../welcome-to-pancakeswap/how-to-guides/get-started-aptos/cake-bridging-guide.md).

--- a/welcome-to-pancakeswap/vecake-sunset/gauges-voting/incentivizing-liquidity.md
+++ b/welcome-to-pancakeswap/vecake-sunset/gauges-voting/incentivizing-liquidity.md
@@ -2,8 +2,4 @@
 
 <figure><img src="../../../.gitbook/assets/image (5) (1).png" alt=""><figcaption></figcaption></figure>
 
-For projects that wish to incentivize liquidity via the veCAKE system, please visit here:
-
-{% content-ref url="/broken/pages/A92bGrvvUwSv2C1TnvLi" %}
-[Broken link](/broken/pages/A92bGrvvUwSv2C1TnvLi)
-{% endcontent-ref %}
+For projects that wish to incentivize liquidity via the veCAKE system, please reach out via our [social channels](../../contact-us/social-accounts.md).


### PR DESCRIPTION
## Documentation Sync — 2026-08-31 (auto-applied)

Generated automatically by the doc-sync cloud routine. All changes below were applied without a human gate — please review before merging.

### Low-risk fixes (typos, broken links, formatting)

- `archive/old-tokenomics/README.md`: removed a dead `/broken/pages/-MYccH_bJjPXGyPCweA8` link on "Pancake Profile" (unlinked the text — no live target exists to point it at) and removed a dangling `{% content-ref url="/broken/pages/-MLAzz7i0mcBCSvWcZbU" %}` block (GitBook "broken-reference" placeholder with no recoverable target).
- `welcome-to-pancakeswap/vecake-sunset/gauges-voting/incentivizing-liquidity.md`: removed a dangling `{% content-ref url="/broken/pages/A92bGrvvUwSv2C1TnvLi" %}` block and replaced it with a plain-text pointer to the Social Accounts page so the CTA isn't just deleted outright.

### High-risk fixes (synced from codebase)

- `bridge/bridging/README.md`: added **Monad** to the "Chains Currently Supported" bullet list for the PancakeSwap Bridge. The same page's "CAKE, a multichain token" section already states CAKE is bridgeable 1:1 to Monad, so the supported-chains list was internally inconsistent (self-contradiction on the same page).
- `earn/yield-farming/farming-on-aptos/faq.md`: fixed a stale CAKE max-supply figure. It said the total supply "will be capped at 750M, according to our v2 tokenomic litepaper" — this is a stale figure from the pre-2026 tokenomics. Updated to 400M and reworded from future to present tense ("is capped"), matching the current, already-correct figure used elsewhere in the docs.

### Source verification

- CAKE 400M supply cap: corroborated by `protocol/cake-tokenomics.md` ("Yes, CAKE now has a hard cap set at 400M... A proposal for the latest cap adjustment was put forward on January 16, 2026 to decrease the cap from 450M to 400M"), `welcome-to-pancakeswap/contact-us/faq/README.md` ("CAKE now has a hard cap of 400M"), and `bridge/bridging/README.md` ("total supply of CAKE across all blockchains is capped at 400M") — all three already agree on 400M and cite the same [governance proposal](https://pancakeswap.finance/voting/proposal/0xc988547f7b6c435764c840623685b0c2d13ebcc91d1672d39c51b6d14207f9a5). The Aptos FAQ was the sole outlier still citing the old 750M litepaper figure.
- Monad bridge support: `bridge/bridging/README.md`'s own "CAKE, a multichain token" section (same file) lists Monad among the chains CAKE is native/bridgeable to; `welcome-to-pancakeswap/how-to-guides/get-started-monad/` has a full dedicated Monad onboarding section (wallet setup, getting MON, bridging via monadbridge.com), and `pancake-frontend`'s `packages/chains/src/chains/monad.ts` config carries `features: { v2: true, v3: true, farms: true }`, confirming Monad is a live, integrated chain, not a placeholder.
- Broken `/broken/pages/...` references: confirmed via `grep -r "broken-reference\|/broken/pages/"` across the repo — these are GitBook's own dead-link marker left over from a page deletion/move upstream in GitBook, with no way to recover the original target from the repo content.

### Needs reviewer decision

None — all findings in this pass had clear, evidence-backed fixes.

### Pages scanned (no drift)

Full forward/reverse scan covered all `trade/`, `earn/`, `bridge/`, `play/`, `tokenomics/`, `products/`, and `protocol/` pages plus supporting FAQs/guides. Notable pages specifically cross-checked against `pancake-frontend` source and found correct / already up to date:
- Chain and sunset-chain lists (`packages/chains/src/chainId.ts`, `chains/*.ts`) — active chain set (Ethereum, BSC, zkSync, opBNB, Arbitrum, Linea, Base, Monad, Robinhood) and sunset set (Polygon zkEVM, Polygon zkEVM Testnet) both match; no doc mentions Polygon zkEVM as still active (only in `archive/` pages, correctly).
- CAKE OFT bridge addresses in `bridge/bridging/README.md` (BNB/Ethereum/Aptos/Arbitrum/zkSync/Linea/Base/opBNB/Solana table).
- `trade/pancakeswap-infinity/` pages, `trade/perpetual-trading/perpetuals-trading-new/README.md` (new Aster-powered Perps rebuild), `trade/pancakeswap-x/` (RWA/Robinhood chain coverage) — all reflect current shipped features, no stale "V3 is latest" or pre-Infinity language found.
- GitBook markup integrity: all `{% hint %}`/`{% endhint %}` and `{% tabs %}`/`{% endtabs %}` blocks balanced repo-wide; all Markdown/HTML image references resolve to real files under `.gitbook/assets/`.
- No doubled-word typos, common misspellings, or mismatched social-link text/href found repo-wide.
- "Coming soon" / "will be available" language on `play/prediction/prediction-faq.md`, Aptos/Monad wallet guides, Perps Degen Mode, `limit-orders-faq.md`, and `bridge/faq/README.md` checked against current `pancake-frontend` code (no evidence these described features have since shipped) — left as-is.

---
Auto-generated by doc-sync routine. @ChefEric @chef-miso please review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLySVfvAgFF87vkQeUn5sj)_